### PR TITLE
disable row menu if demo

### DIFF
--- a/src/components/Sources/Sources.tsx
+++ b/src/components/Sources/Sources.tsx
@@ -73,7 +73,7 @@ export const Sources = () => {
             aria-haspopup="true"
             aria-expanded={open ? 'true' : undefined}
             onClick={(event) =>
-              handleClick(source.sourceId, event.currentTarget)
+              globalContext?.CurrentOrg.state.is_demo ? {} : handleClick(source.sourceId, event.currentTarget)
             }
             variant="contained"
             key={'menu-' + idx}


### PR DESCRIPTION
for demo accounts we don't allow editing or deleting of sources. this PR disables the actions menu for sources on demo accounts