### PR TITLE
connections are not required

### DIFF
--- a/src/components/Flows/FlowCreate.tsx
+++ b/src/components/Flows/FlowCreate.tsx
@@ -411,7 +411,6 @@ const FlowCreate = ({
                             name="connections"
                             variant="outlined"
                             label="Connections"
-                            required
                             error={!!errors.connections}
                             helperText={errors.connections?.message}
                           />


### PR DESCRIPTION
remove the asterisk from the connections input field i.e. make it non-mandatory