### PR TITLE
Update form title for editing existing connections

### DIFF
--- a/src/components/Connections/CreateConnectionForm.tsx
+++ b/src/components/Connections/CreateConnectionForm.tsx
@@ -620,7 +620,7 @@ const CreateConnectionForm = ({
       <CustomDialog
         maxWidth={false}
         data-testid="dialog"
-        title={'Add a new connection'}
+        title={connectionId ? 'Edit this connection' : 'Add a new connection'}
         show={showForm}
         handleClose={handleClose}
         handleSubmit={handleSubmit(onSubmit)}


### PR DESCRIPTION
Goals
- [x] When editing an existing connection, the title should say "Edit this connection"

Acceptance Criteria
- [x] New connection setup should continue to have the title "Add a new connection"
- [x] Existing connections being edited should have the title "Edit this connection"

fixes #753
