### PR TITLE
add full outer join

### DIFF
--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/JoinOpForm.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/JoinOpForm.tsx
@@ -19,7 +19,7 @@ export interface SecondaryInput {
 }
 
 interface JoinDataConfig {
-  join_type: 'left' | 'inner';
+  join_type: 'left' | 'inner' | 'full outer';
   join_on: { key1: string; key2: string; compare_with: string };
   other_inputs: SecondaryInput[];
   source_columns: string[];
@@ -450,7 +450,7 @@ const JoinOpForm = ({
               helperText={fieldState.error?.message}
               fieldStyle="transformation"
               disabled={action === 'view'}
-              options={['left', 'right', 'inner']}
+              options={['left', 'right', 'inner', 'full outer']}
               label="Select the join type*"
             />
           )}


### PR DESCRIPTION
generated
```
{{ config(materialized='table', schema='intermediate') }}
WITH cte1 as (

SELECT "t1"."_airbyte_extracted_at",
"t1"."_airbyte_meta",
"t1"."_airbyte_raw_id",
"t1"."data",
"t1"."id",
"t1"."indexed_on",
"t2"."_airbyte_extracted_at" AS "_airbyte_extracted_at_2",
"t2"."_airbyte_meta" AS "_airbyte_meta_2",
"t2"."_airbyte_raw_id" AS "_airbyte_raw_id_2",
"t2"."data" AS "data_2",
"t2"."id" AS "id_2",
"t2"."indexed_on" AS "indexed_on_2"
 FROM {{source('staging', 'airbyte_MS_visit')}} t1
 FULL OUTER JOIN {{source('staging', 'airbyte_Adolescent_Info')}} t2
 ON "t1"."id" = "t2"."id"
)
-- Final SELECT statement combining the outputs of all CTEs
SELECT *
FROM cte1
```

which ran to produce logs without errors:


<img width="570" alt="image" src="https://github.com/DalgoT4D/webapp/assets/2160416/aca3a923-02b3-408d-9cd2-2e79504f4bba">
