### PR TITLE
fix: Specified the width of Bar Graph and added the scrollbar.

### DIFF
--- a/src/pages/pipeline/index.tsx
+++ b/src/pages/pipeline/index.tsx
@@ -156,8 +156,9 @@ const BarChart = ({ runs, selectFlowRun }: any) => {
   }, []);
 
   return (
-    <div>
-      <svg ref={svgRef} width="100%" height={58}></svg>
+    <div style={{ overflowX: 'auto' }}>
+      {/* runs.length * (barWidth + margin) is the specified width */}
+      <svg ref={svgRef} width={runs.length * 14 + 'px'} height={58}></svg>
     </div>
   );
 };


### PR DESCRIPTION
# Summary

This PR fixes the  #855 . 
Here i have specified the width of the bar Chart as per the number of bars.
Also added the Scrollbar which will be displayed when the screen is narrowed and the chart gets truncated otherwise the scrollbar will not be displayed.

## Goals Achieved

- [x] Scroll bar beneath each bar chart.
- [x] When the screen is wide enough to accommodate the entire chart, the scroll bar should do nothing.
- [x] When the screen is narrow enough that the bar chart gets truncated, the user should be able to scroll to see the entire chart.
- [x] Scrolling one chart should not affect other charts on the page.