### PR TITLE
support for `null` in ui4t operations

### DIFF
--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/CaseWhenOpForm.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/CaseWhenOpForm.tsx
@@ -20,6 +20,7 @@ import Input from '@/components/UI/Input/Input';
 import { OperationFormProps } from '../../OperationConfigLayout';
 import { Autocomplete } from '@/components/UI/Autocomplete/Autocomplete';
 import InfoTooltip from '@/components/UI/Tooltip/Tooltip';
+import { parseStringForNull } from '@/utils/common';
 
 interface GenericOperand {
   value: string;
@@ -324,7 +325,10 @@ const CaseWhenOpForm = ({
                     col_val: string;
                     const_val: string;
                   }) => ({
-                    value: op.type === 'col' ? op.col_val : op.const_val,
+                    value:
+                      op.type === 'col'
+                        ? op.col_val
+                        : parseStringForNull(op.const_val),
                     is_col: op.type === 'col',
                   })
                 )
@@ -333,7 +337,7 @@ const CaseWhenOpForm = ({
                 value:
                   clause.then.type === 'col'
                     ? clause.then.col_val
-                    : clause.then.const_val,
+                    : parseStringForNull(clause.then.const_val),
                 is_col: clause.then.type === 'col',
               },
               operator: clause.logicalOp.id,
@@ -343,7 +347,7 @@ const CaseWhenOpForm = ({
             value:
               data.else.type === 'col'
                 ? data.else.col_val
-                : data.else.const_val,
+                : parseStringForNull(data.else.const_val),
             is_col: data.else.type === 'col',
           },
           sql_snippet: data.sql_snippet,

--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/GenericColumnOpForm.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/GenericColumnOpForm.tsx
@@ -18,6 +18,7 @@ import { GlobalContext } from '@/contexts/ContextProvider';
 import { errorToast } from '@/components/ToastMessage/ToastHelper';
 import { OperationFormProps } from '../../OperationConfigLayout';
 import { Autocomplete } from '@/components/UI/Autocomplete/Autocomplete';
+import { parseStringForNull } from '@/utils/common';
 
 export interface GenericCol {
   function_name: string;
@@ -66,7 +67,7 @@ const GenericColumnOpForm = ({
       operands: {
         type: string;
         col_val: string;
-        const_val: number | undefined;
+        const_val: string | undefined;
       }[];
       output_column_name: string;
     }[];
@@ -126,10 +127,13 @@ const GenericColumnOpForm = ({
               (op: {
                 type: string;
                 col_val: string;
-                const_val: number | undefined;
+                const_val: string | undefined;
               }) => ({
                 is_col: op.type === 'col',
-                value: op.type === 'col' ? op.col_val : op.const_val,
+                value:
+                  op.type === 'col'
+                    ? op.col_val
+                    : parseStringForNull(op.const_val),
               })
             ),
             output_column_name: item.output_column_name,
@@ -306,7 +310,6 @@ const GenericColumnOpForm = ({
                         fieldStyle="transformation"
                         sx={{ padding: '0' }}
                         placeholder="Enter a numeric value"
-                        type="number"
                         disabled={action === 'view'}
                       />
                     )}

--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/ReplaceValueOpForm.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/ReplaceValueOpForm.tsx
@@ -11,6 +11,7 @@ import Input from '@/components/UI/Input/Input';
 import { OperationFormProps } from '../../OperationConfigLayout';
 import { Autocomplete } from '@/components/UI/Autocomplete/Autocomplete';
 import { GridTable } from '@/components/UI/GridTable/GridTable';
+import { parseStringForNull } from '@/utils/common';
 
 interface ReplaceOp {
   find: string;
@@ -114,8 +115,8 @@ const ReplaceValueOpForm = ({
       data.config.forEach((item: any) => {
         if (item.old && item.new)
           postData.config.columns[0].replace_ops.push({
-            find: item.old,
-            replace: item.new,
+            find: parseStringForNull(item.old),
+            replace: parseStringForNull(item.new),
           });
       });
 

--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/WhereFilterOpForm.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/WhereFilterOpForm.tsx
@@ -21,6 +21,7 @@ import { OperationFormProps } from '../../OperationConfigLayout';
 import { Autocomplete } from '@/components/UI/Autocomplete/Autocomplete';
 import InfoTooltip from '@/components/UI/Tooltip/Tooltip';
 import { LogicalOperators } from './CaseWhenOpForm';
+import { parseStringForNull } from '@/utils/common';
 
 interface GenericOperand {
   value: string;
@@ -124,7 +125,7 @@ const WhereFilterOpForm = ({
                 value:
                   data.operand.type === 'col'
                     ? data.operand.col_val
-                    : data.operand.const_val,
+                    : parseStringForNull(data.operand.const_val),
                 is_col: data.operand.type === 'col',
               },
             },

--- a/src/utils/common.tsx
+++ b/src/utils/common.tsx
@@ -114,3 +114,11 @@ export const trimString = (string: string, length: number) => {
     string
   );
 };
+
+export const parseStringForNull = (st: string | null | undefined) => {
+  if (st === null || st === undefined) {
+    return null;
+  }
+
+  return st.trim().toLowerCase() === 'null' ? null : st;
+};


### PR DESCRIPTION
adds support for parsing `null` string to null object. tested operations
- [x] generic column op
- [x] case when op
- [x] filter op
- [x] replace op

Corresponding`dbt-automation` PR - https://github.com/DalgoT4D/dbt-automation/pull/119