### PR TITLE
Allow empty in replace op params

### DIFF
--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationConfigLayout.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationConfigLayout.tsx
@@ -218,8 +218,6 @@ const OperationConfigLayout = ({
     setSelectedOp(op);
   };
 
-  console.log(selectedOp);
-
   useEffect(() => {
     if (canvasAction.type === 'open-opconfig-panel') {
       setOpenPanel(true);

--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/CaseWhenOpForm.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/CaseWhenOpForm.tsx
@@ -171,10 +171,6 @@ const ClauseOperands = ({
                   control={control}
                   key={`clauses.${clauseIndex}.operands.${operandIndex}.const_val`}
                   name={`clauses.${clauseIndex}.operands.${operandIndex}.const_val`}
-                  rules={{
-                    required:
-                      data.advanceFilter === 'no' && 'Value is required',
-                  }}
                   render={({ field, fieldState }) => (
                     <Input
                       helperText={fieldState.error?.message}
@@ -632,10 +628,6 @@ const CaseWhenOpForm = ({
                       <Controller
                         control={control}
                         key={`clauses.${clauseIndex}.then.const_val`}
-                        rules={{
-                          required:
-                            advanceFilter === 'no' && 'Value is required',
-                        }}
                         name={`clauses.${clauseIndex}.then.const_val`}
                         render={({ field, fieldState }) => (
                           <Input

--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/GenericColumnOpForm.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/GenericColumnOpForm.tsx
@@ -78,7 +78,7 @@ const GenericColumnOpForm = ({
       computed_columns: [
         {
           function_name: '',
-          operands: [{ type: 'col', col_val: '', const_val: undefined }],
+          operands: [{ type: 'col', col_val: '', const_val: '' }],
           output_column_name: '',
         },
       ],
@@ -239,6 +239,27 @@ const GenericColumnOpForm = ({
               />
             )}
           />
+          {fields.length === 0 && (
+            <Button
+              disabled={action === 'view'}
+              variant="shadow"
+              type="button"
+              data-testid="addoperand"
+              sx={{
+                marginTop: '17px',
+                marginRight: '3px',
+              }}
+              onClick={(event) =>
+                append({
+                  type: 'col',
+                  col_val: '',
+                  const_val: '',
+                })
+              }
+            >
+              + Add operand
+            </Button>
+          )}
           {fields.map((field, index) => {
             const radioValue = watch(
               `computed_columns.0.operands.${index}.type`
@@ -299,7 +320,6 @@ const GenericColumnOpForm = ({
                   <Controller
                     key={`operands.${index}.const_val`}
                     control={control}
-                    rules={{ required: 'Value is required' }}
                     name={`computed_columns.0.operands.${index}.const_val`}
                     render={({ field, fieldState }) => (
                       <Input
@@ -309,13 +329,13 @@ const GenericColumnOpForm = ({
                         label=""
                         fieldStyle="transformation"
                         sx={{ padding: '0' }}
-                        placeholder="Enter a numeric value"
+                        placeholder="Enter a numeric or string value"
                         disabled={action === 'view'}
                       />
                     )}
                   />
                 )}
-                {index === fields.length - 1 ? (
+                {index === fields.length - 1 && (
                   <Button
                     disabled={action === 'view'}
                     variant="shadow"
@@ -323,30 +343,31 @@ const GenericColumnOpForm = ({
                     data-testid="addoperand"
                     sx={{
                       marginTop: '17px',
+                      marginRight: '3px',
                     }}
                     onClick={(event) =>
                       append({
                         type: 'col',
                         col_val: '',
-                        const_val: undefined,
+                        const_val: '',
                       })
                     }
                   >
                     + Add operand
                   </Button>
-                ) : index < fields.length - 1 ? (
+                )}
+                {index < fields.length && (
                   <Button
                     disabled={action === 'view'}
-                    variant="outlined"
+                    variant="shadow"
                     type="button"
+                    color="error"
                     data-testid="removeoperand"
                     sx={{ marginTop: '17px' }}
                     onClick={(event) => remove(index)}
                   >
                     Remove
                   </Button>
-                ) : (
-                  ''
                 )}
               </Box>
             );

--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/ReplaceValueOpForm.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/ReplaceValueOpForm.tsx
@@ -113,7 +113,7 @@ const ReplaceValueOpForm = ({
       };
 
       data.config.forEach((item: any) => {
-        if (item.old && item.new)
+        if (item.old || item.new)
           postData.config.columns[0].replace_ops.push({
             find: parseStringForNull(item.old),
             replace: parseStringForNull(item.new),

--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/WhereFilterOpForm.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/WhereFilterOpForm.tsx
@@ -334,9 +334,6 @@ const WhereFilterOpForm = ({
                 control={control}
                 key="operand.const_val"
                 name="operand.const_val"
-                rules={{
-                  required: advanceFilter === 'no' && 'Value is required',
-                }}
                 render={({ field, fieldState }) => (
                   <Input
                     {...field}


### PR DESCRIPTION
The empty string should be an allowed value in the same operations which allow `null` as a value