### PR TITLE
minor change - use resetConnDeploymentId for resetting

### DIFF
--- a/src/components/Connections/Connections.tsx
+++ b/src/components/Connections/Connections.tsx
@@ -86,6 +86,7 @@ export type Connection = {
   normalize: boolean;
   status: string;
   syncCatalog: object;
+  resetConnDeploymentId: string;
 };
 
 const truncateString = (input: string) => {


### PR DESCRIPTION
@mdshamoon could you help take this over

the reset connection api needs to change to use `resetConnectionDeploymentId` and hit the same api as sync connection but with this deployment id `resetConnectionDeploymentId`. 