### PR TITLE
dont filter in the initial call

### DIFF
--- a/src/components/TransformWorkflow/FlowEditor/Components/LowerSectionTabs/StatisticsPane.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/LowerSectionTabs/StatisticsPane.tsx
@@ -331,14 +331,6 @@ export const StatisticsPane: React.FC<StatisticsPaneProps> = ({ height }) => {
           column_name: column.name,
         };
 
-        if (column.translated_type === 'Datetime') {
-          postBody.filter = {
-            range: 'year',
-            limit: 10,
-            offset: 0,
-          };
-        }
-
         const metrics: { task_id: string } = await httpPost(
           session,
           metricsApiUrl,


### PR DESCRIPTION
Removing the default filter. Backend has the default year filter.

The logic is when you filter the backend only runs the chart queries but initially we want to run all the queries & wait for the results. Due to this some results were missing and hence the weird bug which Rohit raised for `ANC_PNC_visit` table