### PR TITLE
temporarily disable change confirmation

### DIFF
--- a/src/components/Connections/SchemaChangeDetailsForm.tsx
+++ b/src/components/Connections/SchemaChangeDetailsForm.tsx
@@ -445,10 +445,10 @@ const SchemaChangeDetailsForm = ({
               <Button
                 variant="contained"
                 type="submit"
-                disabled={hasBreakingChanges}
+                disabled={true}
                 sx={{ marginTop: '20px' }}
               >
-                Yes, I approve
+                Temporarily Disabled
               </Button>
             )}
             <Button


### PR DESCRIPTION
we have a bug which sometimes applies the a schema config to the wrong connection

disabling the frontend confirmation step until we figure this out