### PR TITLE
issue/959 dbt tests failed status on the orchestrate page as well

### DIFF
--- a/src/components/Flows/Flows.tsx
+++ b/src/components/Flows/Flows.tsx
@@ -152,9 +152,16 @@ export const Flows = ({
       jobStatus = 'queued';
     }
 
-    // if lock is not there; check for last run
     if (jobStatus === null && flow.lastRun) {
-      if (flow.lastRun?.status === 'COMPLETED') {
+      const state_name = flow.lastRun?.state_name;
+      const status =
+        state_name === 'DBT_TEST_FAILED'
+          ? 'dbt tests failed'
+          : flow.lastRun?.status;
+      if (status === 'dbt tests failed') {
+        jobStatus = 'dbt test failed';
+        jobStatusColor = '#df8e14';
+      } else if (status === 'COMPLETED') {
         jobStatus = 'success';
         jobStatusColor = '#399D47';
       } else {

--- a/src/components/Flows/SingleFlowRunHistory.tsx
+++ b/src/components/Flows/SingleFlowRunHistory.tsx
@@ -16,13 +16,14 @@ export type FlowRun = {
   id: string;
   name: string;
   status: string;
+  state_name: string;
   lastRun: string;
   startTime: string | null;
   expectedStartTime: string;
 };
 
 interface SingleFlowRunHistoryProps {
-  flowRun: FlowRun | null | undefined;
+  flowRun: Partial<FlowRun> | null | undefined;
 }
 
 export const SingleFlowRunHistory = ({


### PR DESCRIPTION
-> The issue was that the last run status used to show success if the dbt test failed. 
- It was because we were checking the status field in the data. Even if the dbt test failed the status used to be "COMPLETED" , hence success was shown on the orchestrate page.
- Now, we are checking the state_name field, and based on that we are showing the status in the ui.