### PR TITLE
while editing now we can edit the dropdowns other than the source type

### DIFF
--- a/src/components/ConfigInput/ConfigInput.tsx
+++ b/src/components/ConfigInput/ConfigInput.tsx
@@ -196,7 +196,7 @@ export const ConfigInput = ({
                 rules={{ required: spec.required && 'Required' }}
                 render={({ field, fieldState }) => (
                   <Autocomplete
-                    disabled={entity ? true : false}
+                    disabled={false}
                     data-testid="autocomplete"
                     id={spec.field}
                     value={field.value}


### PR DESCRIPTION
- The issue was that the dropdowns in the source forms were disabled while editing, but airbyte allowed it.
- Fix: now we can edit the dropdowns other than the source type .