### PR TITLE
1088 ai summary should not be clickable for successful runs and there should be a notification that this feature only works for failures

### DIFF
--- a/src/components/Connections/ConnectionLogs.tsx
+++ b/src/components/Connections/ConnectionLogs.tsx
@@ -335,7 +335,6 @@ export const ConnectionLogs: React.FC<ConnectionLogsProps> = ({
           connection.connectionId,
           session
         );
-        console.log(totalSyncs, "toatl", offset, defaultLoadMoreLimit)
         if (history) {
           setLogDetails(history);
           setTotalSyncs(totalSyncs);

--- a/src/components/Connections/ConnectionLogs.tsx
+++ b/src/components/Connections/ConnectionLogs.tsx
@@ -249,7 +249,7 @@ const Row = ({
           p: 2,
 
           background:
-            logDetail.status === 'failed' ? 'rgba(211, 47, 47, 0.3)' : 'unset',
+            logDetail.status === 'failed' ? 'rgba(211, 47, 47, 0.2)' : 'unset',
         }}
       >
         <TableCell

--- a/src/components/Connections/ConnectionLogs.tsx
+++ b/src/components/Connections/ConnectionLogs.tsx
@@ -368,14 +368,11 @@ export const ConnectionLogs: React.FC<ConnectionLogsProps> = ({
             <Typography sx={{ fontWeight: 700 }}>
               {`${connection?.name} |`}
             </Typography>
-            <Box sx={{ display: "flex", width: "90%", justifyContent: "space-between" }}>
+            <Box sx={{ display: "flex", width: "90%" }}>
               <Typography sx={{ fontWeight: 600, ml: '4px' }}>
                 {connection?.source.sourceName} →{' '}
                 {connection?.destination.destinationName}
               </Typography>
-              {!!flags?.allowLogsSummary &&
-                <Typography sx={{ fontWeight: 400 }}>*For AI summary of failed logs press the AI Summary button</Typography>
-              }
             </Box>
           </Box>
         </Box>

--- a/src/components/Connections/ConnectionLogs.tsx
+++ b/src/components/Connections/ConnectionLogs.tsx
@@ -323,9 +323,10 @@ export const ConnectionLogs: React.FC<ConnectionLogsProps> = ({
   const { data: flags } = useSWR('organizations/flags');
   const [logDetails, setLogDetails] = useState<LogObject[]>([]);
   const [offset, setOffset] = useState(defaultLoadMoreLimit);
-  const [showLoadMore, setShowLoadMore] = useState(true);
+  const [totalSyncs, setTotalSyncs] = useState(0);
   const [loadMorePressed, setLoadMorePressed] = useState(false);
   const [loading, setLoading] = useState(false);
+  const showLoadMore = totalSyncs > offset; //derived value
   useEffect(() => {
     (async () => {
       if (connection) {
@@ -334,12 +335,10 @@ export const ConnectionLogs: React.FC<ConnectionLogsProps> = ({
           connection.connectionId,
           session
         );
+        console.log(totalSyncs, "toatl", offset, defaultLoadMoreLimit)
         if (history) {
           setLogDetails(history);
-        }
-
-        if (totalSyncs <= offset + defaultLoadMoreLimit) {
-          setShowLoadMore(false);
+          setTotalSyncs(totalSyncs);
         }
         setLoading(false);
       }
@@ -457,9 +456,7 @@ export const ConnectionLogs: React.FC<ConnectionLogsProps> = ({
                       if (history) {
                         setLogDetails((logs) => [...logs, ...history]);
                         setOffset((offset) => offset + defaultLoadMoreLimit);
-                      }
-                      if (totalSyncs <= offset + defaultLoadMoreLimit) {
-                        setShowLoadMore(false);
+                        setTotalSyncs(totalSyncs)
                       }
                       setLoadMorePressed(false);
                     }

--- a/src/components/Connections/ConnectionLogs.tsx
+++ b/src/components/Connections/ConnectionLogs.tsx
@@ -133,17 +133,17 @@ const LogsColumn = ({
       ) : null}
       {action === 'summary'
         ? summarizedLogs.length > 0 && (
-            <Alert icon={false} severity="success" sx={{ mb: 2 }}>
-              {summarizedLogs.map((result: any, index: number) => (
-                <Box key={result.prompt} sx={{ mb: 2 }}>
-                  <Box>
-                    <strong>{index === 0 ? 'Summary' : result.prompt}</strong>
-                  </Box>
-                  <Box sx={{ fontWeight: 500 }}>{result.response}</Box>
+          <Alert icon={false} severity="success" sx={{ mb: 2 }}>
+            {summarizedLogs.map((result: any, index: number) => (
+              <Box key={result.prompt} sx={{ mb: 2 }}>
+                <Box>
+                  <strong>{index === 0 ? 'Summary' : result.prompt}</strong>
                 </Box>
-              ))}
-            </Alert>
-          )
+                <Box sx={{ fontWeight: 500 }}>{result.response}</Box>
+              </Box>
+            ))}
+          </Alert>
+        )
         : null}
 
       {action === 'detail' && logs.length > 0 && (
@@ -249,7 +249,7 @@ const Row = ({
           p: 2,
 
           background:
-            logDetail.status === 'failed' ? 'rgba(211, 47, 47, 0.04)' : 'unset',
+            logDetail.status === 'failed' ? 'rgba(211, 47, 47, 0.3)' : 'unset',
         }}
       >
         <TableCell
@@ -269,13 +269,14 @@ const Row = ({
         <TableCell
           sx={{
             fontWeight: 500,
-            borderTopRightRadius: '10px',
-            borderBottomRightRadius: '10px',
           }}
         >
           {formatDuration(logDetail.totalTimeInSeconds)}
         </TableCell>
-        <TableCell sx={{ width: '300px', fontWeight: 500 }}>
+        <TableCell sx={{
+          width: '300px', fontWeight: 500, borderTopRightRadius: '10px',
+          borderBottomRightRadius: '10px',
+        }}>
           <ToggleButtonGroup
             size="small"
             color="primary"
@@ -286,12 +287,12 @@ const Row = ({
             onChange={handleAction}
             aria-label="text alignment"
           >
-            <ToggleButton value="detail" aria-label="left" data-testid="logs">
-               Logs
+            <ToggleButton value="detail" aria-label="left" data-testid="logs" >
+              Logs
               <AssignmentIcon sx={{ ml: '2px', fontSize: '16px' }} />
             </ToggleButton>
-            {(allowLogsSummary && logDetail.status === "failed"  )&& (
-              <ToggleButton value="summary" aria-label="right" data-testid={`aisummary-${connectionId}`}>
+            {(allowLogsSummary && logDetail.status === "failed") && (
+              <ToggleButton value="summary" aria-label="right" data-testid={`aisummary-${connectionId}`} >
                 AI summary <InsightsIcon sx={{ ml: '2px', fontSize: '16px' }} />
               </ToggleButton>
             )}
@@ -329,7 +330,7 @@ export const ConnectionLogs: React.FC<ConnectionLogsProps> = ({
     (async () => {
       if (connection) {
         setLoading(true);
-        const {history =[] , totalSyncs = 0}: {history: LogObject[],totalSyncs: number } = await fetchAirbyteLogs(
+        const { history = [], totalSyncs = 0 }: { history: LogObject[], totalSyncs: number } = await fetchAirbyteLogs(
           connection.connectionId,
           session
         );
@@ -444,7 +445,7 @@ export const ConnectionLogs: React.FC<ConnectionLogsProps> = ({
                   onClick={async () => {
                     setLoadMorePressed(true);
                     if (connection) {
-                      const {history =[], totalSyncs = 0}: {history:LogObject[], totalSyncs: number} = await fetchAirbyteLogs(
+                      const { history = [], totalSyncs = 0 }: { history: LogObject[], totalSyncs: number } = await fetchAirbyteLogs(
                         connection.connectionId,
                         session,
                         offset

--- a/src/components/Connections/ConnectionLogs.tsx
+++ b/src/components/Connections/ConnectionLogs.tsx
@@ -32,6 +32,7 @@ import InsightsIcon from '@mui/icons-material/Insights';
 import AssignmentIcon from '@mui/icons-material/Assignment';
 import useSWR from 'swr';
 
+
 const fetchAirbyteLogs = async (
   connectionId: string,
   session: any,
@@ -43,7 +44,7 @@ const fetchAirbyteLogs = async (
       `airbyte/v1/connections/${connectionId}/sync/history?limit=${defaultLoadMoreLimit}&offset=${offset}`
     );
 
-    return response.history || [];
+    return response;
   } catch (err: any) {
     console.error(err);
   }
@@ -328,15 +329,15 @@ export const ConnectionLogs: React.FC<ConnectionLogsProps> = ({
     (async () => {
       if (connection) {
         setLoading(true);
-        const response: LogObject[] = await fetchAirbyteLogs(
+        const {history =[] , totalSyncs = 0}: {history: LogObject[],totalSyncs: number } = await fetchAirbyteLogs(
           connection.connectionId,
           session
         );
-        if (response) {
-          setLogDetails(response);
+        if (history) {
+          setLogDetails(history);
         }
 
-        if (response.length < defaultLoadMoreLimit) {
+        if (totalSyncs <= offset + defaultLoadMoreLimit) {
           setShowLoadMore(false);
         }
         setLoading(false);
@@ -443,16 +444,16 @@ export const ConnectionLogs: React.FC<ConnectionLogsProps> = ({
                   onClick={async () => {
                     setLoadMorePressed(true);
                     if (connection) {
-                      const response: LogObject[] = await fetchAirbyteLogs(
+                      const {history =[], totalSyncs = 0}: {history:LogObject[], totalSyncs: number} = await fetchAirbyteLogs(
                         connection.connectionId,
                         session,
                         offset
                       );
-                      if (response) {
-                        setLogDetails((logs) => [...logs, ...response]);
+                      if (history) {
+                        setLogDetails((logs) => [...logs, ...history]);
                         setOffset((offset) => offset + defaultLoadMoreLimit);
                       }
-                      if (response.length < defaultLoadMoreLimit) {
+                      if (totalSyncs <= offset + defaultLoadMoreLimit) {
                         setShowLoadMore(false);
                       }
                       setLoadMorePressed(false);

--- a/src/components/Connections/ConnectionLogs.tsx
+++ b/src/components/Connections/ConnectionLogs.tsx
@@ -345,7 +345,6 @@ export const ConnectionLogs: React.FC<ConnectionLogsProps> = ({
       }
     })();
   }, []);
-
   return (
     <Dialog
       sx={{
@@ -371,10 +370,15 @@ export const ConnectionLogs: React.FC<ConnectionLogsProps> = ({
             <Typography sx={{ fontWeight: 700 }}>
               {`${connection?.name} |`}
             </Typography>
-            <Typography sx={{ fontWeight: 600, ml: '4px' }}>
-              {connection?.source.sourceName} →{' '}
-              {connection?.destination.destinationName}
-            </Typography>
+            <Box sx={{ display: "flex", width: "90%", justifyContent: "space-between" }}>
+              <Typography sx={{ fontWeight: 600, ml: '4px' }}>
+                {connection?.source.sourceName} →{' '}
+                {connection?.destination.destinationName}
+              </Typography>
+              {!!flags?.allowLogsSummary &&
+                <Typography sx={{ fontWeight: 400 }}>*For AI summary of failed logs press the AI Summary button</Typography>
+              }
+            </Box>
           </Box>
         </Box>
         <TableContainer

--- a/src/components/Connections/ConnectionLogs.tsx
+++ b/src/components/Connections/ConnectionLogs.tsx
@@ -290,7 +290,7 @@ const Row = ({
                Logs
               <AssignmentIcon sx={{ ml: '2px', fontSize: '16px' }} />
             </ToggleButton>
-            {allowLogsSummary && (
+            {(allowLogsSummary && logDetail.status === "failed"  )&& (
               <ToggleButton value="summary" aria-label="right" data-testid={`aisummary-${connectionId}`}>
                 AI summary <InsightsIcon sx={{ ml: '2px', fontSize: '16px' }} />
               </ToggleButton>

--- a/src/components/Connections/Connections.tsx
+++ b/src/components/Connections/Connections.tsx
@@ -480,7 +480,7 @@ export const Connections = () => {
 
     return (
       <Box
-        sx={{ display: 'flex', flexDirection: 'column', alignItems: 'left' }}
+        sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
       >
         {jobStatus &&
           (['success', 'failed'].includes(jobStatus) ? (
@@ -528,7 +528,7 @@ export const Connections = () => {
             sx={{
               paddingY: '4px',
               paddingX: '2px',
-              width: '60%',
+              width: '80%',
               justifyContent: 'center',
               alignItems: 'center',
             }}

--- a/src/components/Connections/__tests__/ConnectionLogs.test.tsx
+++ b/src/components/Connections/__tests__/ConnectionLogs.test.tsx
@@ -66,7 +66,7 @@ const sampleLogs = [
     logs: ['Log 5', 'Log 6'],
     recordsCommitted: 1000,
     recordsEmitted: 1000,
-    status: 'completed',
+    status: 'failed',
     totalTimeInSeconds: 60,
   },
   {
@@ -95,10 +95,10 @@ const renderWithProviders = (ui: React.ReactElement) => {
     </GlobalContext.Provider>
   );
 };
-
+const sampleTotalSyncs = 20;
 describe('ConnectionLogs Component', () => {
   beforeEach(() => {
-    mockedHttpGet.mockResolvedValue({ history: sampleLogs });
+    mockedHttpGet.mockResolvedValue({ history: sampleLogs, totalSyncs: sampleTotalSyncs  });
     useSWR.mockReturnValue({
       data: { allowLogsSummary: true },
       error: null,
@@ -139,7 +139,7 @@ describe('ConnectionLogs Component', () => {
   });
 
   it('loads more logs when "load more" is clicked', async () => {
-    mockedHttpGet.mockResolvedValueOnce({ history: sampleLogs });
+    mockedHttpGet.mockResolvedValueOnce({ history: sampleLogs, totalSyncs: sampleTotalSyncs });
     renderWithProviders(
       <ConnectionLogs
         setShowLogsDialog={jest.fn()}
@@ -183,11 +183,11 @@ describe('ConnectionLogs Component', () => {
 
     const button = screen.getAllByTestId('aisummary-123');
     if (button.length) {
-      fireEvent.click(button[0]);
+      fireEvent.click(button[0]); //only failed ones.
       await waitFor(() =>
         expect(mockedHttpGet).toHaveBeenCalledWith(
           expect.anything(),
-          `airbyte/v1/connections/123/logsummary?job_id=1&attempt_number=1`
+          `airbyte/v1/connections/123/logsummary?job_id=1&attempt_number=3`
         )
       );
     }
@@ -211,14 +211,14 @@ describe('ConnectionLogs Component', () => {
       />
     );
 
-    await waitFor(() => expect(screen.getByText('100MB')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('300MB')).toBeInTheDocument());
     const firstLabelTextButton = screen.getAllByTestId('logs');
-    fireEvent.click(firstLabelTextButton[0]);
+    fireEvent.click(firstLabelTextButton[2]);
 
     await waitFor(() =>
       expect(mockedHttpGet).toHaveBeenCalledWith(
         expect.anything(),
-        `airbyte/v1/logs?job_id=1&attempt_number=1`
+        `airbyte/v1/logs?job_id=1&attempt_number=3`
       )
     );
 

--- a/src/components/Flows/FlowLogs.tsx
+++ b/src/components/Flows/FlowLogs.tsx
@@ -278,7 +278,7 @@ const Row = ({
           {moment(logDetail.startTime).format('MMMM D, YYYY')}
         </TableCell>
 
-        <TableCell colSpan={3} sx={{ fontWeight: 500,  borderTopRightRadius: "10px", borderBottomRightRadius: "10px" }}>
+        <TableCell colSpan={3} sx={{ fontWeight: 500, borderTopRightRadius: "10px", borderBottomRightRadius: "10px" }}>
           {logDetail.runs.map((run) => (
             <LogsContainer
               key={run.id}
@@ -346,18 +346,16 @@ export const FlowLogs: React.FC<FlowLogsProps> = ({
       />
       <Box sx={{ p: '0px 28px' }}>
         <Box sx={{ mb: 1 }}>
-          <Box sx={{ fontSize: '16px', display: 'flex',justifyContent:"space-between" }}>
-            <Box sx={{display: "flex"}}>
-              <Typography sx={{ fontWeight: 700 }}>
-                {`${flow?.name} |`}
-              </Typography>
-              <Typography sx={{ fontWeight: 600, ml: '4px' }}>
-                {flow?.status ? 'Active' : 'Inactive'}
-              </Typography>
-            </Box>
-            {!!flags?.allowLogsSummary &&
-              <Typography sx={{ fontWeight: 400 }}>*For AI summary of failed logs press the AI Summary button</Typography>
-            }
+          <Box sx={{ fontSize: '16px', display: 'flex', }}>
+
+            <Typography sx={{ fontWeight: 700 }}>
+              {`${flow?.name} |`}
+            </Typography>
+            <Typography sx={{ fontWeight: 600, ml: '4px' }}>
+              {flow?.status ? 'Active' : 'Inactive'}
+            </Typography>
+
+
           </Box>
         </Box>
         <TableContainer

--- a/src/components/Flows/FlowLogs.tsx
+++ b/src/components/Flows/FlowLogs.tsx
@@ -200,7 +200,7 @@ const LogsContainer = ({
               Logs
               <AssignmentIcon sx={{ ml: '2px', fontSize: '16px' }} />
             </ToggleButton>
-            {allowLogsSummary && (
+            {allowLogsSummary && run.state_type === "FAILED" && (
               <ToggleButton value="summary" aria-label="right" data-testid={`aisummary-${run.id}`}>
                 AI summary <InsightsIcon sx={{ ml: '2px', fontSize: '16px' }} />
               </ToggleButton>
@@ -221,17 +221,17 @@ const LogsContainer = ({
         {summarizedLogsLoading ? <LinearProgress color="inherit" /> : null}
         {action === 'summary'
           ? summarizedLogs.length > 0 && (
-              <Alert icon={false} severity="success" sx={{ mb: 2 }}>
-                {summarizedLogs.map((result: any, index: number) => (
-                  <Box key={result.prompt} sx={{ mb: 2 }}>
-                    <Box>
-                      <strong>{index === 0 ? 'Summary' : result.prompt}</strong>
-                    </Box>
-                    <Box sx={{ fontWeight: 500 }}>{result.response}</Box>
+            <Alert icon={false} severity="success" sx={{ mb: 2 }}>
+              {summarizedLogs.map((result: any, index: number) => (
+                <Box key={result.prompt} sx={{ mb: 2 }}>
+                  <Box>
+                    <strong>{index === 0 ? 'Summary' : result.prompt}</strong>
                   </Box>
-                ))}
-              </Alert>
-            )
+                  <Box sx={{ fontWeight: 500 }}>{result.response}</Box>
+                </Box>
+              ))}
+            </Alert>
+          )
           : null}
 
         {action === 'detail' && run.logs.length > 0 && (
@@ -264,7 +264,7 @@ const Row = ({
           p: 2,
 
           background:
-            logDetail.status === 'FAILED' ? 'rgba(211, 47, 47, 0.04)' : 'unset',
+            logDetail.status === 'FAILED' ? 'rgba(211, 47, 47, 0.2)' : 'unset',
         }}
       >
         <TableCell
@@ -278,7 +278,7 @@ const Row = ({
           {moment(logDetail.startTime).format('MMMM D, YYYY')}
         </TableCell>
 
-        <TableCell colSpan={3} sx={{ fontWeight: 500 }}>
+        <TableCell colSpan={3} sx={{ fontWeight: 500,  borderTopRightRadius: "10px", borderBottomRightRadius: "10px" }}>
           {logDetail.runs.map((run) => (
             <LogsContainer
               key={run.id}
@@ -300,7 +300,7 @@ export const FlowLogs: React.FC<FlowLogsProps> = ({
   const { data: session }: any = useSession();
   const { data: flags } = useSWR('organizations/flags');
   const [logDetails, setLogDetails] = useState<DeploymentObject[]>([]);
-  const [offset, setOffset] = useState(1);
+  const [offset, setOffset] = useState(defaultLoadMoreLimit);
   const [showLoadMore, setShowLoadMore] = useState(true);
   const [loadMorePressed, setLoadMorePressed] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -346,13 +346,18 @@ export const FlowLogs: React.FC<FlowLogsProps> = ({
       />
       <Box sx={{ p: '0px 28px' }}>
         <Box sx={{ mb: 1 }}>
-          <Box sx={{ fontSize: '16px', display: 'flex' }}>
-            <Typography sx={{ fontWeight: 700 }}>
-              {`${flow?.name} |`}
-            </Typography>
-            <Typography sx={{ fontWeight: 600, ml: '4px' }}>
-              {flow?.status ? 'Active' : 'Inactive'}
-            </Typography>
+          <Box sx={{ fontSize: '16px', display: 'flex',justifyContent:"space-between" }}>
+            <Box sx={{display: "flex"}}>
+              <Typography sx={{ fontWeight: 700 }}>
+                {`${flow?.name} |`}
+              </Typography>
+              <Typography sx={{ fontWeight: 600, ml: '4px' }}>
+                {flow?.status ? 'Active' : 'Inactive'}
+              </Typography>
+            </Box>
+            {!!flags?.allowLogsSummary &&
+              <Typography sx={{ fontWeight: 400 }}>*For AI summary of failed logs press the AI Summary button</Typography>
+            }
           </Box>
         </Box>
         <TableContainer
@@ -430,7 +435,7 @@ export const FlowLogs: React.FC<FlowLogsProps> = ({
                         );
                       if (response) {
                         setLogDetails((logs) => [...logs, ...response]);
-                        setOffset((offset) => offset + 1);
+                        setOffset((offset) => offset + defaultLoadMoreLimit);
                       }
                       if (response.length < defaultLoadMoreLimit) {
                         setShowLoadMore(false);

--- a/src/components/Flows/__tests__/FlowLogs.test.tsx
+++ b/src/components/Flows/__tests__/FlowLogs.test.tsx
@@ -52,10 +52,11 @@ const mockLogDetails = [
                 label: 'task 2',
                 start_time: moment().subtract(2, 'hours').toISOString(),
                 end_time: moment().toISOString(),
+                state_type: "FAILED",
                 logs: [{ level: 1, message: 'Log message 2', timestamp: moment().toISOString() }],
             },
         ],
-        status: 'COMPLETED',
+        status: 'FAILED',
     },
     {
         id: 'log-3',
@@ -275,13 +276,12 @@ describe('FlowLogs Component', () => {
         });
 
         // Check that the AI summary button is present
-        expect(screen.getByTestId('aisummary-run-1')).toBeInTheDocument();
+        expect(screen.getByTestId('aisummary-run-2')).toBeInTheDocument();
 
         // Simulate clicking the AI summary button
-        fireEvent.click(screen.getByTestId("aisummary-run-1"));
-        console.log(screen.getByTestId("aisummary-run-1").outerHTML, "summary");
+        fireEvent.click(screen.getByTestId("aisummary-run-2"));
         await waitFor(() => {
-            expect(screen.queryByTestId("aisummary-run-1")).toBeDisabled();
+            expect(screen.queryByTestId("aisummary-run-2")).toBeDisabled();
         })
         
 


### PR DESCRIPTION
- Conditionally rendering the Ai summary button for the failed logs.
- Changed the conditions to show the load more button. 