### PR TITLE
1114 cast form not loading

### DIFF
--- a/src/components/TransformWorkflow/FlowEditor/Components/Canvas.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/Canvas.tsx
@@ -188,7 +188,12 @@ const getLayoutedElements = ({
   };
 };
 
-const Canvas = ({ redrawGraph, setRedrawGraph, finalLockCanvas,setTempLockCanvas }: CanvasProps) => {
+const Canvas = ({
+  redrawGraph,
+  setRedrawGraph,
+  finalLockCanvas,
+  setTempLockCanvas,
+}: CanvasProps) => {
   const { data: session } = useSession();
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
@@ -210,7 +215,7 @@ const Canvas = ({ redrawGraph, setRedrawGraph, finalLockCanvas,setTempLockCanvas
     },
   };
   // const [tempLockCanvas, setTempLockCanvas] = useState(true);
-    // const finalLockCanvas = tempLockCanvas || lockUpperSection;
+  // const finalLockCanvas = tempLockCanvas || lockUpperSection;
   const fetchDbtProjectGraph = async () => {
     setTempLockCanvas(true);
     try {
@@ -332,7 +337,7 @@ const Canvas = ({ redrawGraph, setRedrawGraph, finalLockCanvas,setTempLockCanvas
         data: null,
       });
     }
-    
+
     if (shouldRefreshGraph) setRedrawGraph(!redrawGraph); //calls api in parent and this comp rerenders.
   };
 
@@ -372,22 +377,20 @@ const Canvas = ({ redrawGraph, setRedrawGraph, finalLockCanvas,setTempLockCanvas
     }
   };
 
-  const handleRefreshCanvas = () => {
-   
-    setRedrawGraph(!redrawGraph);
-  };
+  // const handleRefreshCanvas = () => {
+  //   setRedrawGraph(!redrawGraph);
+  // };
 
   useEffect(() => {
     // This event is triggered via the ProjectTree component
     if (canvasAction.type === 'add-srcmodel-node') {
-
       addSrcModelNodeToCanvas(canvasAction.data);
     }
 
-    if (canvasAction.type === 'refresh-canvas') {
-      setTempLockCanvas(true);
-      handleRefreshCanvas();
-    }
+    // if (canvasAction.type === 'refresh-canvas') {
+    //   setTempLockCanvas(true);
+    //   handleRefreshCanvas();
+    // }
 
     if (canvasAction.type === 'delete-node') {
       setTempLockCanvas(true);
@@ -480,7 +483,7 @@ const Canvas = ({ redrawGraph, setRedrawGraph, finalLockCanvas,setTempLockCanvas
           zIndex: (theme) => theme.zIndex.drawer + 1,
         }}
         open={finalLockCanvas}
-        onClick={() => { }}
+        onClick={() => {}}
       >
         <CircularProgress
           sx={{
@@ -530,6 +533,10 @@ const Canvas = ({ redrawGraph, setRedrawGraph, finalLockCanvas,setTempLockCanvas
               onClick={() => {
                 successToast('Graph has been refreshed', [], globalContext);
                 setRedrawGraph(!redrawGraph);
+                setCanvasAction({
+                  type: 'refresh-canvas',
+                  data: null,
+                });
               }}
             >
               <ReplayIcon />

--- a/src/components/TransformWorkflow/FlowEditor/Components/Nodes/DbtSourceModelNode.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/Nodes/DbtSourceModelNode.tsx
@@ -10,7 +10,7 @@ import {
   tableCellClasses,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { useContext, useMemo, useRef, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Handle, Position, useNodeId, useEdges, Edge } from 'reactflow';
 import { SrcModelNodeType } from '../Canvas';
 import { httpGet } from '@/helpers/http';
@@ -92,7 +92,7 @@ const NodeDataTableComponent = ({ columns }: { columns: ColumnData[] }) => {
 export function DbtSourceModelNode(node: SrcModelNodeType) {
   const { data: session } = useSession();
   const { setPreviewAction } = usePreviewAction();
-  const { setCanvasAction } = useCanvasAction();
+  const { canvasAction, setCanvasAction } = useCanvasAction();
   const { setCanvasNode } = useCanvasNode();
   const [columns, setColumns] = useState<Array<any>>([]);
   const globalContext = useContext(GlobalContext);
@@ -141,7 +141,7 @@ export function DbtSourceModelNode(node: SrcModelNodeType) {
   };
 
   useMemo(() => {
-    const cacheKey = `${node.data.schema}/${node.data.input_name}`;
+    const cacheKey = `${node.data.schema}/${node.data.input_name}-${nodeId}`;
 
     if (cacheRef.current[cacheKey]) {
       setColumns(cacheRef.current[cacheKey]);
@@ -160,6 +160,12 @@ export function DbtSourceModelNode(node: SrcModelNodeType) {
       })();
     }
   }, [session, edges]);
+
+  useEffect(() => {
+    if (canvasAction.type === 'refresh-canvas') {
+      cacheRef.current = {};
+    }
+  }, [canvasAction]);
 
   return (
     <Box

--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationConfigLayout.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationConfigLayout.tsx
@@ -425,6 +425,7 @@ const OperationConfigLayout = ({
   };
 
   const prepareForNextOperation = async (opNodeData: OperationNodeData) => {
+    // opNodeData - the node that just got saved
     if (opNodeData.id !== canvasNode?.id) {
       const dummyNodeId: string = dummyNodeIdRef.current;
       // get all edges of this dummy node and save
@@ -485,6 +486,9 @@ const OperationConfigLayout = ({
     } else {
       handleClosePanel();
     }
+
+    // refresh canvas
+    setCanvasAction({ type: 'refresh-canvas', data: null });
   };
 
   const panelState = selectedOp


### PR DESCRIPTION

- removed unnecessary api calls to refresh table columns. Before we refetching table columns information for each model on events of adding a dummy node and opening the configuration panel on the right which seemed redundant
- refresh via canvas action disptach event; that is run only when the `refresh` button is pressed or a model is saved.