### PR TITLE
1162 add connection form not resetting to default empty fields after opening the more options model

### DIFF
--- a/src/components/Connections/Connections.tsx
+++ b/src/components/Connections/Connections.tsx
@@ -268,7 +268,11 @@ export const Connections = () => {
     setResetDeploymentId(connection.resetConnDeploymentId);
     setAnchorEl(event);
   };
-  const handleClose = () => {
+  const handleClose = (isEditMode?: string) => {
+    if(isEditMode !== "EDIT"){
+      setConnectionId("");
+      setResetDeploymentId("");
+    }
     setAnchorEl(null);
   };
   const [showDialog, setShowDialog] = useState(false);
@@ -626,7 +630,7 @@ export const Connections = () => {
   };
 
   const handleEditConnection = () => {
-    handleClose();
+    handleClose("EDIT");
     setShowDialog(true);
   };
 

--- a/src/components/Connections/CreateConnectionForm.tsx
+++ b/src/components/Connections/CreateConnectionForm.tsx
@@ -175,6 +175,14 @@ const CreateConnectionForm = ({
         }
         setLoading(false);
       })();
+    }else{
+      reset();
+      setConnectionId('');
+      setSourceStreams([]);
+      setFilteredSourceStreams([]);
+      setSelectAllStreams(false);
+      setIncrementalAllStreams(false);
+      searchInputRef.current = '';
     }
   }, [connectionId]);
 
@@ -363,7 +371,7 @@ const CreateConnectionForm = ({
   const FormContent = () => {
     return (
       <>
-        <Box sx={{ pt: 2, pb: 4 }}>
+        <Box key={connectionId ? "edit-mode" : "add-new-mode"} sx={{ pt: 2, pb: 4 }}>
           <Input
             data-testid="connectionName"
             sx={{ width: '100%' }}
@@ -566,6 +574,7 @@ const CreateConnectionForm = ({
   return (
     <>
       <CustomDialog
+        key={connectionId ? "edit-custom" : "new-custom"}
         maxWidth={false}
         data-testid="dialog"
         title={connectionId ? 'Edit this connection' : 'Add a new connection'}

--- a/src/components/Connections/__tests__/CreateConnection.test.tsx
+++ b/src/components/Connections/__tests__/CreateConnection.test.tsx
@@ -55,10 +55,14 @@ describe('Create connection', () => {
       json: jest.fn().mockResolvedValueOnce([]),
     });
 
+
+
     render(
       <SessionProvider session={mockSession}>
         <CreateConnectionForm
           mutate={() => {}}
+          connectionId=''
+          setConnectionId={() => {}}
           showForm={true}
           setShowForm={() => {}}
           blockId=""
@@ -117,6 +121,8 @@ describe('Create connection', () => {
               showForm={true}
               setShowForm={() => {}}
               setBlockId={() => {}}
+              connectionId=''
+              setConnectionId={() => {}}
               blockId=""
               filteredSourceStreams={SOURCES.slice().sort((a, b) => a.name.localeCompare(b.name))}
             />
@@ -260,6 +266,8 @@ describe('Create connection', () => {
               showForm={true}
               setShowForm={() => {}}
               setBlockId={() => {}}
+              connectionId=''
+              setConnectionId={() => {}}
               blockId=""
             />
           </SWRConfig>
@@ -357,6 +365,8 @@ describe('Create connection', () => {
               showForm={true}
               setShowForm={() => {}}
               setBlockId={() => {}}
+              connectionId=''
+              setConnectionId={() => {}}
               blockId=""
             />
           </SWRConfig>

--- a/src/components/Layouts/Auth.tsx
+++ b/src/components/Layouts/Auth.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Banner from '@/assets/images/banner.png';
 import Logo from '@/assets/images/logo.svg';
 import { ReactNode } from 'react';
+import moment from 'moment';
 
 type AuthProps = {
   children: ReactNode;
@@ -59,7 +60,7 @@ export const Auth: React.FC<AuthProps> = ({
               </Box>
             </Paper>
             <Typography variant="body1" mt={4} pb={3}>
-              2023, DALGO ALL RIGHTS RESERVED
+            {moment().year()}, DALGO ALL RIGHTS RESERVED
             </Typography>
           </Grid>
         </Grid>


### PR DESCRIPTION
 Issue:
   -Create connection form not resetting.

Flow:
   - Click on the (3 dots - more options list) in front of the listed connections.
   - An api is called which sets the connectionId in parent component and hence fills the edit connection form with data.
   - Now if we click on edit , it works fine.
   - but if i close that l(3dots - more options list) by clicking anywhere on the screen, and then click on New connection button, we can see it filled with the data. (Since edit and new Connection form are SAME), its the connectionId that differentiates them.
   
Fix: 
 - set connectionId as "" when the list closes.
 - one problem: when we will click edit, then also list will close, so the edit form will also be empty. 
 - hence check that when the list is being closed, it should not be because of the Edit. 


Reference image->
<img width="760" alt="image" src="https://github.com/user-attachments/assets/11352ece-3267-4495-af3e-e2b1cff1bd29">

