### PR TITLE
Don't want to reset the form when feedback is given.

### DIFF
--- a/src/components/DataAnalysis/LLMSummary.tsx
+++ b/src/components/DataAnalysis/LLMSummary.tsx
@@ -85,7 +85,6 @@ export const LLMSummary = ({
       );
       if (response.success) {
         successToast(`Feedback sent successfully`, [], globalContext);
-        handleNewSession(true);
       }
     } catch (err: any) {
       errorToast(err.message, [], globalContext);

--- a/src/components/DataAnalysis/OverwriteBox.tsx
+++ b/src/components/DataAnalysis/OverwriteBox.tsx
@@ -52,15 +52,12 @@ export const OverWriteDialog = ({
     setIsBoxOpen(false);
   };
   useEffect(() => {
-    console.log(modalName, 'modalname');
     if (oldSessionName && modalName === MODALS.OVERWRITE) {
-      console.log(oldSessionName, 'oldsessino');
       reset({
         sessionName: oldSessionName,
       });
     }
   }, [oldSessionName, modalName]);
-  console.log();
   const ModalData: any = {
     SAVE: {
       mainheading: 'Save as',

--- a/src/components/DataAnalysis/OverwriteBox.tsx
+++ b/src/components/DataAnalysis/OverwriteBox.tsx
@@ -2,8 +2,8 @@ import React, { useEffect } from 'react';
 import { Box, Button, TextField, Typography, DialogActions } from '@mui/material';
 import CustomDialog from '../Dialog/CustomDialog';
 import { useForm, Controller } from 'react-hook-form';
-import { MODALS } from './LLMSummary';
 import { useTracking } from '@/contexts/TrackingContext';
+import { MODALS } from '@/pages/analysis/data-analysis';
 // Define the form data type
 interface FormData {
   sessionName: string;
@@ -18,8 +18,10 @@ export const OverWriteDialog = ({
   onConfirmNavigation,
   setModalName,
   submitFeedback,
-  oldSessionName,
+  oldSessionMetaInfo,
   handleNewSession,
+  handleEditSession,
+  selectedSession,
 }: {
   open: boolean;
   modalName: string;
@@ -29,7 +31,9 @@ export const OverWriteDialog = ({
   setIsBoxOpen: (a: boolean) => void;
   submitFeedback: (x: string) => void;
   handleNewSession: (x: boolean) => void;
-  oldSessionName: string;
+  oldSessionMetaInfo: any;
+  handleEditSession: (x: any, y: boolean) => void;
+  selectedSession: any;
 }) => {
   const trackAmplitudeEvent: any = useTracking();
   const {
@@ -43,7 +47,7 @@ export const OverWriteDialog = ({
       feedback: '',
     },
   });
-
+  const oldSessionName = oldSessionMetaInfo.session_name;
   const handleClose = () => {
     reset({
       sessionName: '',
@@ -249,6 +253,39 @@ export const OverWriteDialog = ({
         },
       ],
     },
+    EDIT_SESSION_WARNING: {
+      mainheading: 'Unsaved session',
+      subHeading:
+        'You are about to leave the session without saving your changes.\nAny unsaved work will be lost. Do you wish to continue?',
+      label: 'Save session',
+      buttons: [
+        {
+          label: 'Save changes',
+          variant: 'contained',
+          sx: {
+            width: '6.75rem',
+            padding: '8px 0',
+            borderRadius: '5px',
+          },
+          onClick: () => {
+            setModalName(oldSessionName ? MODALS.OVERWRITE : MODALS.SAVE);
+          },
+        },
+        {
+          label: 'Leave Anyway',
+          variant: 'contained',
+          sx: {
+            width: '6.75rem',
+            padding: '8px 0',
+            borderRadius: '5px',
+          },
+          onClick: () => {
+            setIsBoxOpen(false);
+            handleEditSession(selectedSession, true);
+          },
+        },
+      ],
+    },
   };
 
   const FormContent = () => {
@@ -264,7 +301,7 @@ export const OverWriteDialog = ({
         >
           {ModalData[modalName].subHeading}
         </Typography>
-        {!['UNSAVED_CHANGES', 'RESET_WARNING'].includes(modalName) && (
+        {!['UNSAVED_CHANGES', 'RESET_WARNING', 'EDIT_SESSION_WARNING'].includes(modalName) && (
           <Box sx={{ marginTop: '1.75rem' }}>
             <Controller
               name={modalName === 'FEEDBACK_FORM' ? 'feedback' : 'sessionName'}

--- a/src/pages/analysis/data-analysis.tsx
+++ b/src/pages/analysis/data-analysis.tsx
@@ -12,6 +12,8 @@ import { TopBar } from '@/components/DataAnalysis/TopBar';
 import { jsonToCSV } from 'react-papaparse';
 import { PageHead } from '@/components/PageHead';
 import { Disclaimer } from '@/components/DataAnalysis/Disclaimer';
+import { OverWriteDialog } from '@/components/DataAnalysis/OverwriteBox';
+import { useRouter } from 'next/router';
 interface ProgressResult {
   response?: Array<any>;
   session_id?: string;
@@ -22,18 +24,34 @@ interface ProgressEntry {
   status: 'running' | 'completed' | 'failed';
   result?: ProgressResult;
 }
+export const MODALS = {
+  SAVE: 'SAVE',
+  OVERWRITE: 'OVERWRITE',
+  CONFIRM_SAVEAS: 'CONFIRM_SAVEAS',
+  FEEDBACK_FORM: 'FEEDBACK_FORM',
+  UNSAVED_CHANGES: 'UNSAVED_CHANGES',
+  RESET_WARNING: 'RESET_WARNING',
+  EDIT_SESSION_WARNING: 'EDIT_SESSION_WARNING',
+};
 
 interface ProgressResponse {
   progress: ProgressEntry[];
 }
 export default function DataAnalysis() {
   const { data: session } = useSession();
+  const router = useRouter();
+  const [attemptedRoute, setAttemptedRoute] = useState(null);
   const globalContext = useContext(GlobalContext);
+  const { dispatch, state } = globalContext?.UnsavedChanges ?? {};
   const [loading, setLoading] = useState(false);
   const [openSavedSessionDialog, setOpenSavedSessionDialog] = useState(false);
   const [resetState, setResetState] = useState(true);
   const [isOpen, setIsOpen] = useState(false);
+  const [selectedSession, setSelectedSession] = useState();
+  const [isBoxOpen, setIsBoxOpen] = useState(false);
+  const [modalName, setModalName] = useState(MODALS.SAVE);
 
+  //for the discalimer page.
   useEffect(() => {
     const orgSlug = localStorage.getItem('org-slug');
     try {
@@ -84,7 +102,14 @@ export default function DataAnalysis() {
     }
     setResetState(true);
   };
-  const handleEditSession = (info: any) => {
+  const handleEditSession = (info: any, openEdit: boolean) => {
+    setSelectedSession(info);
+    //shows me a modal asking to save the generated summary.
+    if (newSessionId && !openEdit) {
+      setIsBoxOpen(true);
+      setModalName(MODALS.EDIT_SESSION_WARNING);
+      return;
+    }
     setSessionMetaInfo({
       newSessionId: '',
       ...oldSessionMetaInfo,
@@ -183,6 +208,102 @@ export default function DataAnalysis() {
       errorToast(err.message, [], globalContext);
     }
   };
+  //handling save session->
+  const handleSaveSession = async (
+    overwrite: boolean,
+    old_session_id: string | null,
+    session_name: string
+  ) => {
+    try {
+      const response: { success: number } = await httpPost(
+        session,
+        `warehouse/ask/${newSessionId}/save`,
+        {
+          session_name,
+          overwrite,
+          old_session_id,
+        }
+      );
+      if (response.success) {
+        successToast(`${session_name} saved successfully`, [], globalContext);
+        handleNewSession(true);
+      }
+    } catch (err: any) {
+      errorToast(err.message, [], globalContext);
+    } finally {
+      setIsBoxOpen(false);
+    }
+  };
+
+  const handleFeedback = async (session_id: string, feedback: string) => {
+    try {
+      const response: { success: number } = await httpPost(
+        session,
+        `warehouse/ask/${session_id}/feedback`,
+        {
+          feedback,
+        }
+      );
+      if (response.success) {
+        successToast(`Feedback sent successfully`, [], globalContext);
+      }
+    } catch (err: any) {
+      errorToast(err.message, [], globalContext);
+    } finally {
+      setIsBoxOpen(false);
+    }
+  };
+
+  // Submitting the session name -> Caan be overwrite or new session.
+  const onSubmit = (sessionName: string, overwrite: boolean) => {
+    const oldSessionIdToSend = overwrite ? oldSessionMetaInfo?.oldSessionId : null;
+    handleSaveSession(overwrite, oldSessionIdToSend, sessionName);
+  };
+
+  //Submitting Feedback
+  const submitFeedback = (feedback: string) => {
+    let sessionIdToSend: any;
+    if (newSessionId) {
+      // if we have a newsession or if we have oldsession but again create a new summary (both oldsessionid and newsessionid).
+      sessionIdToSend = newSessionId;
+    } else if (oldSessionMetaInfo.oldSessionId) {
+      //during edit when we have a oldsession id.
+      sessionIdToSend = oldSessionMetaInfo.oldSessionId;
+    }
+    handleFeedback(sessionIdToSend, feedback);
+  };
+
+  //Warns user to save the session before moving to some other tab.
+  useEffect(() => {
+    const handleRouteChange = (url: any) => {
+      if (
+        (oldSessionMetaInfo.oldSessionId && newSessionId && state === false) ||
+        (newSessionId && !oldSessionMetaInfo.oldSessionId && state === false)
+      ) {
+        router.events.emit('routeChangeError');
+        setModalName(MODALS.UNSAVED_CHANGES);
+        setIsBoxOpen(true);
+        dispatch({ type: 'SET_UNSAVED_CHANGES' });
+        setAttemptedRoute(url);
+        throw 'Unsaved changes, route change aborted';
+      }
+    };
+
+    router.events.on('routeChangeStart', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChange);
+      dispatch({ type: 'CLEAR_UNSAVED_CHANGES' });
+    };
+  }, [router, oldSessionMetaInfo.oldSessionId, state, newSessionId]);
+
+  //the unsaved modal function->
+  const onConfirmNavigation = () => {
+    if (attemptedRoute) {
+      dispatch({ type: 'SET_UNSAVED_CHANGES' });
+      router.push(attemptedRoute);
+    }
+  };
 
   return (
     <>
@@ -222,6 +343,8 @@ export default function DataAnalysis() {
         {/* Final Summary */}
         <LLMSummary
           resetState={resetState}
+          setModalName={setModalName}
+          setIsBoxOpen={setIsBoxOpen}
           llmSummary={summary}
           downloadCSV={downloadCSV}
           newSessionId={newSessionId}
@@ -268,6 +391,21 @@ export default function DataAnalysis() {
           />
         )}
         {isOpen && <Disclaimer open={isOpen} setIsOpen={setIsOpen} />}
+        {isBoxOpen && (
+          <OverWriteDialog
+            open={isBoxOpen}
+            setIsBoxOpen={setIsBoxOpen}
+            modalName={modalName}
+            onSubmit={onSubmit}
+            submitFeedback={submitFeedback}
+            onConfirmNavigation={onConfirmNavigation}
+            handleNewSession={handleNewSession}
+            setModalName={setModalName}
+            oldSessionMetaInfo={oldSessionMetaInfo}
+            handleEditSession={handleEditSession}
+            selectedSession={selectedSession}
+          />
+        )}
       </Box>
     </>
   );


### PR DESCRIPTION
This PR addresses two issues:

1. **Session disappears after feedback is submitted:** The issue was resolved by removing the `handleNewSession` function, which caused the session to reset.

2. **Modal for unsaved session when opening a saved session:** Now, if the user generates a new summary and attempts to open a saved session `without` saving the current one, a modal prompts the user to either save the session or proceed with opening the selected one.
     - I refactored it by moving the OverwriteBox component from LLMSummary.tsx to the parent component dataanalysis.tsx.
