### PR TITLE
column exclusion logic for renaming columns not working correctly

### DIFF
--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/RenameColumnOpForm.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/RenameColumnOpForm.tsx
@@ -42,7 +42,7 @@ const RenameColumnOp = ({
     },
   });
 
-  const { control, handleSubmit, reset, getValues, formState } = useForm({
+  const { control, handleSubmit, reset, getValues, formState, watch } = useForm({
     defaultValues: {
       config: [{ old: '', new: '' }],
     },
@@ -169,6 +169,12 @@ const RenameColumnOp = ({
 
   const options = srcColumns.filter((column) => !config.map((con) => con.old).includes(column));
 
+  const configValues = watch('config'); //useful for rendering while selecting options or for input.
+  const disableCondition =
+    configValues.length >= srcColumns.length ||
+    configValues.at(-1)?.new === '' ||
+    configValues.at(-1)?.old === '';
+
   return (
     <Box sx={{ ...sx, marginTop: '17px' }}>
       <form onSubmit={handleSubmit(handleSave)}>
@@ -191,6 +197,7 @@ const RenameColumnOp = ({
                   {...field}
                   data-testid={`currentName${index}`}
                   id={`config${index}old`}
+                  value={field.value}
                   onChange={(data: any) => {
                     field.onChange(data);
                     const nextAutocompletIndex = document.querySelector(
@@ -216,10 +223,13 @@ const RenameColumnOp = ({
                   data-testid={`newName${index}`}
                   id={`config${index}new`}
                   fieldStyle="none"
+                  value={field.value}
                   sx={{ padding: '0' }}
+                  onChange={(e) => field.onChange(e.target.value)}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') {
                       e.preventDefault();
+                      if (disableCondition) return;
                       append({ old: '', new: '' });
                     }
                   }}
@@ -236,12 +246,13 @@ const RenameColumnOp = ({
         )}
 
         <Button
-          disabled={action === 'view'}
+          disabled={action === 'view' || disableCondition}
           variant="shadow"
           type="button"
           data-testid="addcase"
           sx={{ m: 2 }}
           onClick={(event) => {
+            if (disableCondition) return;
             append({ old: '', new: '' });
           }}
         >

--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/RenameColumnOpForm.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/RenameColumnOpForm.tsx
@@ -49,6 +49,7 @@ const RenameColumnOp = ({
   });
 
   const { config } = getValues();
+
   // Include this for multi-row input
   const { fields, append, remove } = useFieldArray({
     control,
@@ -149,7 +150,9 @@ const RenameColumnOp = ({
         old: key,
         new: columns[key],
       }));
-      renamedColumnArray.push({ old: '', new: '' });
+      if (renamedColumnArray.length < source_columns.length) {
+        renamedColumnArray.push({ old: '', new: '' });
+      }
       reset({ config: renamedColumnArray });
     } catch (error) {
       console.error(error);
@@ -168,8 +171,8 @@ const RenameColumnOp = ({
   }, [session, node]);
 
   const options = srcColumns.filter((column) => !config.map((con) => con.old).includes(column));
-
   const configValues = watch('config'); //useful for rendering while selecting options or for input.
+
   const disableCondition =
     configValues.length >= srcColumns.length ||
     configValues.at(-1)?.new === '' ||


### PR DESCRIPTION
1. Added a `disableCondition`, which checks that the` Add column button `remains disable 
  1.1. If the user has not completely filled the previous fields i.e. the `current name dropdown `and the `new name input`
  1.2 If the `number of columns to be renamed` equals `total number of columns available` to be renamed.
  
  The above condition disables the Enter key also. Enter key also works the same as Add Column button.


2. Lines 152-155 ensure that if `ALL` the columns have already been renamed, the user will no longer see options to select or rename columns when editing.
  
  
  
