### PR TITLE
mongo db connector issue.

### DIFF
--- a/src/components/ConfigInput/ConfigInput.tsx
+++ b/src/components/ConfigInput/ConfigInput.tsx
@@ -76,6 +76,7 @@ export const ConfigInput = ({ specs, control, setFormValue, entity }: ConfigInpu
       {connectorSpecs
         ?.sort((input1, input2) => input1.order - input2.order)
         .map((spec: EntitySpec) => {
+          console.log(spec, 'PEC');
           return spec?.type === 'string' ? (
             spec?.airbyte_secret ? (
               <React.Fragment key={spec.field}>
@@ -121,6 +122,39 @@ export const ConfigInput = ({ specs, control, setFormValue, entity }: ConfigInpu
                 />
                 <Box sx={{ m: 2 }} />
               </React.Fragment>
+            ) : spec?.enum && spec?.enum.length > 0 ? (
+              <>
+                <React.Fragment key={spec.field}>
+                  <Controller
+                    name={spec.field}
+                    control={control}
+                    rules={{ required: spec.required && 'Required' }}
+                    render={({ field, fieldState }) => (
+                      <Autocomplete
+                        disabled={false}
+                        data-testid="autocomplete"
+                        id={spec.field}
+                        value={field.value}
+                        options={spec.enum as any}
+                        onChange={(e, data: any) => {
+                          handleObjectFieldOnChange(data, spec.field, field);
+                        }}
+                        renderInput={(params) => (
+                          <Input
+                            name={spec.field}
+                            error={!!fieldState.error}
+                            helperText={fieldState.error?.message}
+                            {...params}
+                            variant="outlined"
+                            label={`${spec.title}${spec.required ? '*' : ''}`}
+                          />
+                        )}
+                      />
+                    )}
+                  />
+                  <Box sx={{ m: 2 }} />
+                </React.Fragment>
+              </>
             ) : (
               <React.Fragment key={spec.field}>
                 <Controller

--- a/src/components/ConfigInput/ConfigInput.tsx
+++ b/src/components/ConfigInput/ConfigInput.tsx
@@ -121,7 +121,9 @@ export const ConfigInput = ({ specs, control, setFormValue, entity }: ConfigInpu
                 />
                 <Box sx={{ m: 2 }} />
               </React.Fragment>
-            ) : spec?.enum && spec?.enum.length > 0 ? (
+            ) : spec?.enum &&
+              spec?.enum.length > 0 &&
+              (spec?.specs == null || spec?.specs === undefined) ? (
               //usually parent object containing enum has type object. but in the case of mongodb connector the type was string.
               <>
                 <React.Fragment key={spec.field}>

--- a/src/components/ConfigInput/ConfigInput.tsx
+++ b/src/components/ConfigInput/ConfigInput.tsx
@@ -76,7 +76,6 @@ export const ConfigInput = ({ specs, control, setFormValue, entity }: ConfigInpu
       {connectorSpecs
         ?.sort((input1, input2) => input1.order - input2.order)
         .map((spec: EntitySpec) => {
-          console.log(spec, 'PEC');
           return spec?.type === 'string' ? (
             spec?.airbyte_secret ? (
               <React.Fragment key={spec.field}>
@@ -123,6 +122,7 @@ export const ConfigInput = ({ specs, control, setFormValue, entity }: ConfigInpu
                 <Box sx={{ m: 2 }} />
               </React.Fragment>
             ) : spec?.enum && spec?.enum.length > 0 ? (
+              //usually parent object containing enum has type object. but in the case of mongodb connector the type was string.
               <>
                 <React.Fragment key={spec.field}>
                   <Controller

--- a/src/helpers/ConnectorConfigInput.tsx
+++ b/src/helpers/ConnectorConfigInput.tsx
@@ -168,7 +168,7 @@ class ConnectorConfigInput {
           value['oneOf']?.forEach((ele: any) => {
             if (commonField.length > 0) {
               commonField = Object.keys(ele?.properties)
-                .filter((key: any) => 'const' in ele?.properties[key])
+                .filter((key: any) => 'const' in ele?.properties[key]) // mongodb connector case. Only cluster type had const property and was not at the top level but with the other properties that were to be rendered if a cluster type is selected.
                 .filter((value: any) => commonField.includes(value));
             } else {
               commonField = Object.keys(ele?.properties);

--- a/src/helpers/ConnectorConfigInput.tsx
+++ b/src/helpers/ConnectorConfigInput.tsx
@@ -167,9 +167,9 @@ class ConnectorConfigInput {
         if (value['oneOf'] && value['oneOf'].length > 1) {
           value['oneOf']?.forEach((ele: any) => {
             if (commonField.length > 0) {
-              commonField = Object.keys(ele?.properties).filter((value: any) =>
-                commonField.includes(value)
-              );
+              commonField = Object.keys(ele?.properties)
+                .filter((key: any) => 'const' in ele?.properties[key])
+                .filter((value: any) => commonField.includes(value));
             } else {
               commonField = Object.keys(ele?.properties);
             }


### PR DESCRIPTION
1. Usually, dropdowns that reveal additional fields based on `selected options `are positioned at the top level. However, in the case of MongoDB, the `cluster type dropdown was placed among other fields`, with only c`luster type containing a const field,` . To address this, we applied a` filter function to check the cluster type field and designate it as a commonField.`

2. We added a new condition in `ConfigInput.tsx ` file to check if the `spec type is a string with an enum`. Generally, when an enum is present, the spec type is expected to be an object

<img width="581" alt="Screenshot 2024-10-31 at 6 57 43 PM" src="https://github.com/user-attachments/assets/9e8d7c06-32f9-4100-98ba-0a2dc112d250">

`Image showing the 1st point. See how the Cluster type have different key values then other fields`