### PR TITLE
fixing notification css.

### DIFF
--- a/src/components/Notifications/ManageNotificaitons.tsx
+++ b/src/components/Notifications/ManageNotificaitons.tsx
@@ -16,7 +16,7 @@ import {
   IconButton,
 } from '@mui/material';
 import { ErrorOutline, KeyboardArrowDown, KeyboardArrowUp } from '@mui/icons-material';
-
+const Long_Notification_Length = 130;
 interface Notification {
   id: number;
   urgent: boolean;
@@ -134,7 +134,7 @@ const ManageNotifications = ({
         >
           <TableBody>
             {data?.res?.map((notification: Notification) => {
-              const isMessageLong = notification.message.length > 100;
+              const isMessageLong = notification.message.length > Long_Notification_Length;
 
               return (
                 <TableRow
@@ -186,11 +186,11 @@ const ManageNotifications = ({
                           color: notification.read_status ? '#798696' : '#0F2440E0',
                         }}
                       >
-                        <Typography sx={{ fontWeight: 500, fontSize: '15px' }}>
+                        <Typography sx={{ fontWeight: 700, fontSize: '15px' }}>
                           {/* Truncate the text only when it's not expanded */}
                           {expandedRow === notification.id
                             ? notification.message
-                            : truncateText(notification.message, 100)}
+                            : truncateText(notification.message, Long_Notification_Length)}
                         </Typography>
                         <Typography sx={{ fontWeight: 600, fontSize: '12px' }}>
                           {moment(new Date(notification.timestamp)).fromNow()}


### PR DESCRIPTION
As its in the figma - 
- we don't have a bold heading for a notification right now. Its just a string (message field) coming from backend.
`  {
            "id": 30,
            "author": "Platform Admin",
            "message": "Your pipeline has been running for over 7 hours. The run has been cancelled and our team is looking into the problem on priority.",
            "timestamp": "2024-09-18T09:14:56.960Z",
            "urgent": false,
            "scheduled_time": null,
            "sent_time": "2024-09-18T09:14:58.138Z",
            "read_status": true
        }`
- So to make it more visible I have changed the `font weight to 700. In figma its 600. `
- So I think without the Bold heading,  font weight 700 helps distinguish read and unread notification. 
- If any issues with this, we cant just change the `fontweight field on line number 189` in the `ManageNotifications`.tsx page, to 600. 


<img width="1016" alt="Screenshot 2024-11-07 at 10 42 15 PM" src="https://github.com/user-attachments/assets/57238be4-d146-4770-a46c-9e2402ebe937">
