### PR TITLE
fixed the desitnation form rendering issue

### DIFF
--- a/src/helpers/ConnectorConfigInput.tsx
+++ b/src/helpers/ConnectorConfigInput.tsx
@@ -207,7 +207,6 @@ class ConnectorConfigInput {
           });
         } else if (value['oneOf'] && value['oneOf'].length === 1) {
           const ele = value['oneOf'][0];
-          console.log(ele, 'element');
           commonField = Object.keys(ele?.properties).filter(
             (key: any) => 'const' in ele.properties[key]
           );
@@ -228,7 +227,6 @@ class ConnectorConfigInput {
             enum: [],
             specs: [],
           };
-          console.log(objResult, 'objresult');
           result.push(objResult);
           value?.oneOf?.forEach((eachEnum: any) => {
             ConnectorConfigInput.traverseSpecs(

--- a/src/helpers/ConnectorConfigInput.tsx
+++ b/src/helpers/ConnectorConfigInput.tsx
@@ -81,9 +81,6 @@ class ConnectorConfigInput {
 
   static traverseSpecsToSetOrder(data: any, globalCounter = { count: 0 }) {
     //global counter as an object such that we have a single counter. (pass by refernce concept for objects)
-    if (!globalCounter || typeof globalCounter.count !== 'number') {
-      globalCounter = { count: 0 }; // Ensure initialization
-    }
 
     const dataProperties = data.properties;
 


### PR DESCRIPTION
1. Changed the numbering system :
      Earlier we were doing: 
      **Parent { order:1}:**
          ChildA {order: 1.1}
          ChildB {order: 1.1}
          ChildC {order: 1.1}
      **Parent {order:2}:** 
          ChildA {order: 2.1}
          ChildB {order: 2.1}
          ChildC {order: 2.1}
          
  Issue was when Child 1.1 had grandchild
   **Parent {order:1}:**
          ChildA {order: 1.1}
             `GrandChild {order: 1.2}`.  Now this 1.2 was being rendered below ChildC (we did a sort()). This was messing up the order.
          ChildB {order: 1.1}
          ChildC {order: 1.1}
      **Parent {order:2}:** 
          ChildA {order: 2.1}
          ChildB {order: 2.1}
          ChildC {order: 2.1}
          
          
          New format: I thought of just numbering them in sequence 1, 2, 3, 4, and so on
   
   **Parent {order:1}:**
          ChildA {order: 2}
             `GrandChild 3`.  Now this 1.2 was being rendered below ChildC (we did a sort()). This was messing up the order.
          ChildB {order: 4}
          ChildC {order: 5}
      **Parent {order:6}:** 
          ChildA {order: 7}
          ChildB {order: 8}
          ChildC {order: 9}
          
          
          This way our order is also preserved and we can render in sequence.