### PR TITLE
airbyte upgrade 1.1.0

### DIFF
--- a/src/components/Connections/SchemaChangeDetailsForm.tsx
+++ b/src/components/Connections/SchemaChangeDetailsForm.tsx
@@ -120,24 +120,27 @@ const SchemaChangeDetailsForm = ({
               } else if (transform.transformType === 'add_stream') {
                 changedColumns.push(`+Stream: ${tableName}`);
               } else {
-                changedColumns = transform.updateStream.reduce((columns: string[], update: any) => {
-                  if (
-                    update.transformType === 'add_field' ||
-                    update.transformType === 'remove_field' ||
-                    update.transformType === 'update_field_schema'
-                  ) {
-                    if (update.transformType === 'update_field_schema') {
-                      columns.push(`+${update.fieldName.join(', ')}`);
-                    } else {
-                      columns.push(
-                        `${
-                          update.transformType === 'add_field' ? '+' : '-'
-                        }${update.fieldName.join(', ')}`
-                      );
+                changedColumns = transform.updateStream.fieldTransforms.reduce(
+                  (columns: string[], update: any) => {
+                    if (
+                      update.transformType === 'add_field' ||
+                      update.transformType === 'remove_field' ||
+                      update.transformType === 'update_field_schema'
+                    ) {
+                      if (update.transformType === 'update_field_schema') {
+                        columns.push(`+${update.fieldName.join(', ')}`);
+                      } else {
+                        columns.push(
+                          `${
+                            update.transformType === 'add_field' ? '+' : '-'
+                          }${update.fieldName.join(', ')}`
+                        );
+                      }
                     }
-                  }
-                  return columns;
-                }, []);
+                    return columns;
+                  },
+                  []
+                );
               }
 
               return { name: tableName, changedColumns };

--- a/src/components/Connections/__tests__/SchemaChangeDetailsForm.test.tsx
+++ b/src/components/Connections/__tests__/SchemaChangeDetailsForm.test.tsx
@@ -78,18 +78,20 @@ const nonBreakingData = {
               streamDescriptor: {
                 name: 'worldometer_data',
               },
-              updateStream: [
-                {
-                  transformType: 'add_field',
-                  fieldName: ['Second new column'],
-                  breaking: false,
-                },
-                {
-                  transformType: 'add_field',
-                  fieldName: ['New column of nulls'],
-                  breaking: false,
-                },
-              ],
+              updateStream: {
+                fieldTransforms: [
+                  {
+                    transformType: 'add_field',
+                    fieldName: ['Second new column'],
+                    breaking: false,
+                  },
+                  {
+                    transformType: 'add_field',
+                    fieldName: ['New column of nulls'],
+                    breaking: false,
+                  },
+                ],
+              },
             },
           ],
         },
@@ -347,18 +349,20 @@ describe('SchemaChangeDetailsForm', () => {
                   streamDescriptor: {
                     name: 'worldometer_data',
                   },
-                  updateStream: [
-                    {
-                      transformType: 'add_field',
-                      fieldName: ['Second new column'],
-                      breaking: false,
-                    },
-                    {
-                      transformType: 'add_field',
-                      fieldName: ['New column of nulls'],
-                      breaking: false,
-                    },
-                  ],
+                  updateStream: {
+                    fieldTransforms: [
+                      {
+                        transformType: 'add_field',
+                        fieldName: ['Second new column'],
+                        breaking: false,
+                      },
+                      {
+                        transformType: 'add_field',
+                        fieldName: ['New column of nulls'],
+                        breaking: false,
+                      },
+                    ],
+                  },
                 },
               ],
             },


### PR DESCRIPTION
All the changes here are related to airbyte upgrade (to 1.1.0) based on the new api spec
- Api spec for discover source schema catalog `/v1/sources/discover_schema` has changed. Both `0.63.13` (old staging) and `1.1.0` (new staging) have this updated spec. However prod `0.58.0` doesn't  have this so we wont see the bug there yet.