### PR TITLE
memoized the CreateConnectionForm, to prevent rerenders

### DIFF
--- a/src/components/Connections/CreateConnectionForm.tsx
+++ b/src/components/Connections/CreateConnectionForm.tsx
@@ -453,7 +453,7 @@ const CreateConnectionForm = ({
     setSomeStreamSelected(sourceStreams.some((stream) => stream.selected));
   }, [sourceStreams]);
 
-  const FormContent = () => {
+  const FormContent = useMemo(() => {
     return (
       <>
         <Box key={connectionId ? 'edit-mode' : 'add-new-mode'} sx={{ pt: 2, pb: 4 }}>
@@ -688,7 +688,15 @@ const CreateConnectionForm = ({
         </Box>
       </>
     );
-  };
+  }, [
+    filteredSourceStreams,
+    connectionId,
+    sources,
+    sourceStreams,
+    selectAllStreams,
+    incrementalAllStreams,
+    isAnyCursorAbsent,
+  ]);
 
   return (
     <>
@@ -700,7 +708,7 @@ const CreateConnectionForm = ({
         show={showForm}
         handleClose={handleClose}
         handleSubmit={handleSubmit(onSubmit)}
-        formContent={<FormContent />}
+        formContent={FormContent}
         formActions={
           <>
             <Button variant="contained" type="submit" disabled={!someStreamSelected}>

--- a/src/components/Connections/CreateConnectionForm.tsx
+++ b/src/components/Connections/CreateConnectionForm.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { memo, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
 import CustomDialog from '../Dialog/CustomDialog';
 import {
@@ -717,4 +717,4 @@ const CreateConnectionForm = ({
   );
 };
 
-export default CreateConnectionForm;
+export default memo(CreateConnectionForm);


### PR DESCRIPTION
** Written just to revise the concept.

1. `React.memo` prevents the unnecessary re-renders of a react component.
2. It `memoizes` the value of the component and only re-renders when the `props` from the` parent component change`.

**Interesting**

So in JS we have primitive datatypes (number, string, etc) and non-primitive datatypes (objects , functions etc). 
`Primitive datatypes` are `passed by value`  and `non-primitive` are `passed by reference`.
React.memo does a `shallow comparison` of props.

1. When a parent component re-renders, all variables inside it are recreated 
2. Then they are passed to child component as props.
3. For` primitive values` (e.g., let num = 2), the value remains unchanged, so React.memo works correctly by preventing re-renders.
4. For `non-primitives` (e.g., objects, functions, arrays),` a new reference is created on every render`. Since React.memo performs a shallow comparison, it detects the new reference as a prop change and re-renders the child, even if the actual values inside the object or function haven’t changed.

**Solution:**
1. Wrap the functions with `useCallback()`.  This memoizes the function and ensures it only gets recreated when its dependencies change.
 2. For arrays and object use `useMemo()`.
 
 Since in the CreateConnectionForm, the setState function is being passed which internally uses useCallback to memoize the function, we can pass it directly as prop. 