### PR TITLE
fixed the rerendering issue

### DIFF
--- a/src/pages/analysis/index.tsx
+++ b/src/pages/analysis/index.tsx
@@ -26,21 +26,27 @@ export default function Analysis() {
         }
       }
     });
+
     // ask the iframe where it's at
-    const intervalId = setInterval(function () {
+    const intervalId = setInterval(() => {
       if (iframeRefHidden?.current) {
         if (globalContext?.CurrentOrg?.state.viz_url) {
           iframeRefHidden.current.contentWindow.location.href =
             globalContext?.CurrentOrg?.state.viz_url;
-          setTimeout(() => {
+
+          // Waiting for iframe to load and then send a message
+          iframeRefHidden.current.onload = () => {
             iframeRefHidden?.current?.contentWindow?.postMessage(
               { ask: 'locationStatus' },
-              globalContext?.CurrentOrg?.state.viz_url
+              globalContext.CurrentOrg.state.viz_url
             );
-          }, 500);
+            // clearing the interval since iframe is set
+            clearInterval(intervalId);
+          };
         }
       }
     }, 2000);
+
     return () => {
       clearInterval(intervalId);
     };


### PR DESCRIPTION
- I suppose the setTimeout was there to wait for the iframe to load. 
- I have added an onload event listener that clears the interval when the iframe is loaded. 
- The clearInterval which is added in the clean up function only works if the component is mounted or unmounted. Hence we need a separate clearInterval inside the onload function. 