### PR TITLE
Added email field to create org form when the base plan is free_trial.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ cloudbuild.yaml
 
 # Sentry Config File
 .env.sentry-build-plugin
+.qodo

--- a/src/components/Org/CreateOrgForm.tsx
+++ b/src/components/Org/CreateOrgForm.tsx
@@ -72,8 +72,6 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
     } else if (response?.status === 'failed') {
       errorToast(response?.message, [], globalContext);
       return;
-    } else if (response?.status === 'completed') {
-      successToast(response?.message, [], globalContext);
     } else {
       throw new Error('Error while running the task.');
     }
@@ -95,7 +93,7 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
     setWaitForOrgCreation(true);
     try {
       if (data.base_plan === OrgPlan.FREE_TRIAL) {
-        const res = await httpPost(session, '/v1/organizations/free_trial', payload);
+        const res = await httpPost(session, 'v1/organizations/free_trial', payload);
         if (!res?.task_id) {
           errorToast('Failed to create a task', [], globalContext);
           return;

--- a/src/components/Org/CreateOrgForm.tsx
+++ b/src/components/Org/CreateOrgForm.tsx
@@ -153,12 +153,18 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
           <Controller
             name="email"
             control={control}
-            rules={{ required: 'Account manager email is required' }}
+            rules={{
+              required: 'Account manager email is required',
+              pattern: {
+                value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                message: 'Invalid email address',
+              },
+            }}
             render={({ field }) => (
               <Input
                 {...field}
                 data-testid="input-email"
-                error={!!errors.name}
+                error={!!errors.email}
                 helperText={errors.email?.message}
                 sx={{ mb: 2, width: '100%' }}
                 label="Email - Account Manager"

--- a/src/components/Org/CreateOrgForm.tsx
+++ b/src/components/Org/CreateOrgForm.tsx
@@ -46,6 +46,8 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
       name: '',
       base_plan: '', //DALGO , Free trail and Internal
       email: '',
+      superset_ec2_machine_id: '',
+      superset_port: '',
       superset_included: '',
       duration: '',
       startDate: '',
@@ -66,6 +68,8 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
       name: data.name,
       base_plan: data.base_plan,
       email: data.email ? data.email : '',
+      superset_ec2_machine_id: data.superset_ec2_machine_id ? data.superset_ec2_machine_id : '',
+      superset_port: data.superset_port ? data.superset_port : '',
       subscription_duration: data.duration,
       can_upgrade_plan: !data.superset_included || data.base_plan === 'Free Trial' ? true : false,
       superset_included: data.superset_included === 'Yes' ? true : false,
@@ -168,6 +172,48 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
                 helperText={errors.email?.message}
                 sx={{ mb: 2, width: '100%' }}
                 label="Email - Account Manager"
+                variant="outlined"
+              />
+            )}
+          />
+        )}
+        {/* superset ec2 machine id */}
+        {base_plan === OrgPlan.FREE_TRIAL && (
+          <Controller
+            name="superset_ec2_machine_id"
+            control={control}
+            rules={{
+              required: 'Superset ec2 machine id is required',
+            }}
+            render={({ field }) => (
+              <Input
+                {...field}
+                data-testid="input-superset_ec2_machine_id"
+                error={!!errors.superset_ec2_machine_id}
+                helperText={errors.superset_ec2_machine_id?.message}
+                sx={{ mb: 2, width: '100%' }}
+                label="Superset EC2 Machine ID"
+                variant="outlined"
+              />
+            )}
+          />
+        )}
+        {/* superset port */}
+        {base_plan === OrgPlan.FREE_TRIAL && (
+          <Controller
+            name="superset_port"
+            control={control}
+            rules={{
+              required: 'Superset port is required',
+            }}
+            render={({ field }) => (
+              <Input
+                {...field}
+                data-testid="input-superset_port"
+                error={!!errors.superset_port}
+                helperText={errors.superset_port?.message}
+                sx={{ mb: 2, width: '100%' }}
+                label="Superset Port"
                 variant="outlined"
               />
             )}

--- a/src/components/Org/CreateOrgForm.tsx
+++ b/src/components/Org/CreateOrgForm.tsx
@@ -65,14 +65,14 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
   };
 
   const pollForTaskRun = async (taskId: string) => {
-    const response = await httpGet(session, `/celery/${taskId}`);
-    if (!['completed', 'failed'].includes(response?.status)) {
+    const response = await httpGet(session, `tasks/celery/${taskId}`);
+    if (!['SUCCESS', 'FAILURE'].includes(response?.status)) {
       await delay(3000);
       await pollForTaskRun(taskId);
-    } else if (response?.status === 'failed') {
+    } else if (response?.status === 'FAILED') {
       errorToast(response?.message, [], globalContext);
       return;
-    } else if (response?.status === 'completed') {
+    } else if (response?.status === 'SUCCESS') {
       return;
     } else {
       throw new Error('Error while running the task.');

--- a/src/components/Org/CreateOrgForm.tsx
+++ b/src/components/Org/CreateOrgForm.tsx
@@ -81,11 +81,9 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
     const payload = {
       name: data.name,
       base_plan: data.base_plan,
-      email: data.email ? data.email : '',
-      superset_ec2_machine_id: data.superset_ec2_machine_id ? data.superset_ec2_machine_id : '',
-      superset_port: data.superset_port ? data.superset_port : '',
       subscription_duration: data.duration,
-      can_upgrade_plan: !data.superset_included || data.base_plan === 'Free Trial' ? true : false,
+      can_upgrade_plan:
+        !data.superset_included || data.base_plan === OrgPlan.FREE_TRIAL ? true : false,
       superset_included: data.superset_included === 'Yes' ? true : false,
       start_date: data.startDate ? new Date(data.startDate).toISOString() : null,
       end_date: data.endDate ? new Date(data.endDate).toISOString() : null,
@@ -93,7 +91,12 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
     setWaitForOrgCreation(true);
     try {
       if (data.base_plan === OrgPlan.FREE_TRIAL) {
-        const res = await httpPost(session, 'v1/organizations/free_trial', payload);
+        const res = await httpPost(session, 'v1/organizations/free_trial', {
+          ...payload,
+          superset_ec2_machine_id: data.superset_ec2_machine_id,
+          superset_port: data.superset_port,
+          email: data.email,
+        });
         if (!res?.task_id) {
           errorToast('Failed to create a task', [], globalContext);
           return;
@@ -233,6 +236,7 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
               <Input
                 {...field}
                 data-testid="input-superset_port"
+                type="number"
                 error={!!errors.superset_port}
                 helperText={errors.superset_port?.message}
                 sx={{ mb: 2, width: '100%' }}

--- a/src/components/Org/CreateOrgForm.tsx
+++ b/src/components/Org/CreateOrgForm.tsx
@@ -72,6 +72,8 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
     } else if (response?.status === 'failed') {
       errorToast(response?.message, [], globalContext);
       return;
+    } else if (response?.status === 'completed') {
+      return;
     } else {
       throw new Error('Error while running the task.');
     }

--- a/src/components/Org/CreateOrgForm.tsx
+++ b/src/components/Org/CreateOrgForm.tsx
@@ -45,12 +45,14 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
     defaultValues: {
       name: '',
       base_plan: '', //DALGO , Free trail and Internal
+      email: '',
       superset_included: '',
       duration: '',
       startDate: '',
       endDate: '',
     },
   });
+  const base_plan = watch('base_plan');
   const globalContext = useContext(GlobalContext);
 
   const handleClose = () => {
@@ -63,6 +65,7 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
     const payload = {
       name: data.name,
       base_plan: data.base_plan,
+      email: data.email ? data.email : '',
       subscription_duration: data.duration,
       can_upgrade_plan: !data.superset_included || data.base_plan === 'Free Trial' ? true : false,
       superset_included: data.superset_included === 'Yes' ? true : false,
@@ -128,6 +131,7 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
                   setValue('duration', 'Trial');
                 } else {
                   setValue('duration', '');
+                  setValue('email', '');
                 }
               }}
               renderInput={(params) => (
@@ -144,6 +148,25 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
           )}
         />
 
+        {/* Account manager's email: To send the credentials to the account manager conducting the POC */}
+        {base_plan === OrgPlan.FREE_TRIAL && (
+          <Controller
+            name="email"
+            control={control}
+            rules={{ required: 'Account manager email is required' }}
+            render={({ field }) => (
+              <Input
+                {...field}
+                data-testid="input-email"
+                error={!!errors.name}
+                helperText={errors.email?.message}
+                sx={{ mb: 2, width: '100%' }}
+                label="Email - Account Manager"
+                variant="outlined"
+              />
+            )}
+          />
+        )}
         {/* Superset included */}
         <Controller
           name="superset_included"

--- a/src/components/Org/__tests__/CreateOrgForm.test.tsx
+++ b/src/components/Org/__tests__/CreateOrgForm.test.tsx
@@ -1,17 +1,26 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { GlobalContext } from '@/contexts/ContextProvider';
 import { CreateOrgForm } from '../CreateOrgForm';
 import { errorToast, successToast } from '@/components/ToastMessage/ToastHelper';
-import { httpPost } from '@/helpers/http';
+import { httpGet, httpPost } from '@/helpers/http';
 
 // Mock dependencies
 jest.mock('next-auth/react');
 jest.mock('next/navigation');
 jest.mock('../../../helpers/http');
 jest.mock('../../ToastMessage/ToastHelper');
+
+// Mock localStorage
+const localStorageMock = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  clear: jest.fn(),
+};
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
 
 describe('CreateOrgForm Component', () => {
   const mockSession = {
@@ -26,10 +35,42 @@ describe('CreateOrgForm Component', () => {
       state: [],
       dispatch: jest.fn(),
     },
-    Toast: { showToast: jest.fn() },
-    CurrentOrg: null,
-    OrgUsers: [],
-    UnsavedChanges: { hasUnsavedChanges: false, setHasUnsavedChanges: jest.fn() },
+    Toast: {
+      state: {
+        open: false,
+        message: '',
+        severity: 'success' as const,
+        seconds: 3000,
+        handleClose: jest.fn(),
+      },
+      dispatch: jest.fn(),
+    },
+    CurrentOrg: {
+      state: {
+        slug: '',
+        name: '',
+        base_plan: '',
+        subscription_duration: '',
+        can_upgrade_plan: false,
+        superset_included: false,
+        start_date: null,
+        end_date: null,
+        airbyte_workspace_id: '',
+        viz_url: '',
+        viz_login_type: '',
+        wtype: '',
+        is_demo: false,
+      },
+      dispatch: jest.fn(),
+    },
+    OrgUsers: {
+      state: [],
+      dispatch: jest.fn(),
+    },
+    UnsavedChanges: {
+      state: false,
+      dispatch: jest.fn(),
+    },
   };
 
   beforeEach(() => {
@@ -37,6 +78,9 @@ describe('CreateOrgForm Component', () => {
     (useRouter as jest.Mock).mockReturnValue(mockRouter);
     (errorToast as jest.Mock).mockImplementation(jest.fn());
     (successToast as jest.Mock).mockImplementation(jest.fn());
+    (httpGet as jest.Mock).mockResolvedValue({ status: 'SUCCESS' });
+    localStorageMock.setItem.mockClear();
+    localStorageMock.getItem.mockClear();
   });
 
   const renderComponent = (props = {}) => {
@@ -60,7 +104,6 @@ describe('CreateOrgForm Component', () => {
 
   it('renders form fields correctly', () => {
     renderComponent();
-    // expect(screen.getByLabelText(/Organization name/i)).toBeInTheDocument();
     expect(screen.getByTestId('savebutton')).toBeInTheDocument();
     expect(screen.getByTestId('cancelbutton')).toBeInTheDocument();
   });
@@ -86,79 +129,88 @@ describe('CreateOrgForm Component', () => {
       expect(screen.getByText(/Organization name is required/i)).toBeInTheDocument();
     });
   });
+
   it('submits the form correctly and handles the response', async () => {
     const closeSideMenu = jest.fn();
     const setShowForm = jest.fn();
     // Mock the response for httpPost
-    httpPost.mockResolvedValueOnce({ slug: 'new-org-slug' });
+    (httpPost as jest.Mock).mockResolvedValueOnce({ slug: 'new-org-slug' });
 
-    // Render the component
-    render(
-      <GlobalContext.Provider value={mockGlobalContext}>
-        <CreateOrgForm closeSideMenu={closeSideMenu} showForm={true} setShowForm={setShowForm} />
-      </GlobalContext.Provider>
-    );
+    renderComponent({ closeSideMenu, setShowForm });
 
     // Fill in the organization name
     const inputOrgDiv = screen.getByTestId('input-orgname');
     const inputOrg = within(inputOrgDiv).getByRole('textbox');
     fireEvent.change(inputOrg, { target: { value: 'New Org' } });
 
-    // Select base plan
+    // Select base plan - Dalgo
     const basePlanAutoComplete = screen.getByTestId('baseplan');
-    const basePlanTextInput = within(basePlanAutoComplete).getByRole('combobox');
-    basePlanAutoComplete.focus();
-    await fireEvent.change(basePlanTextInput, {
-      target: { value: 'Dalgo' },
+    const basePlanInput = within(basePlanAutoComplete).getByRole('combobox');
+
+    // Focus and type to open dropdown
+    fireEvent.focus(basePlanInput);
+    fireEvent.change(basePlanInput, { target: { value: 'Dalgo' } });
+
+    // Select the option
+    await act(async () => {
+      const option = screen.getByText('Dalgo');
+      fireEvent.click(option);
     });
-    fireEvent.keyDown(basePlanAutoComplete, { key: 'ArrowDown' });
-    await act(() => fireEvent.keyDown(basePlanAutoComplete, { key: 'Enter' }));
 
     // Select superset included
     const supersetIncludedAutoComplete = screen.getByTestId('superset_included');
-    const supersetIncludedValue = within(supersetIncludedAutoComplete).getByRole('combobox');
-    supersetIncludedAutoComplete.focus();
-    await fireEvent.change(supersetIncludedValue, {
-      target: { value: 'Yes' },
+    const supersetIncludedInput = within(supersetIncludedAutoComplete).getByRole('combobox');
+
+    // Focus and type to open dropdown
+    fireEvent.focus(supersetIncludedInput);
+    fireEvent.change(supersetIncludedInput, { target: { value: 'Yes' } });
+
+    // Select the option
+    await act(async () => {
+      const option = screen.getByText('Yes');
+      fireEvent.click(option);
     });
-    fireEvent.keyDown(supersetIncludedAutoComplete, { key: 'ArrowDown' });
-    await act(() => fireEvent.keyDown(supersetIncludedAutoComplete, { key: 'Enter' }));
 
     // Select duration
-    const selectDurationAutoComplete = screen.getByTestId('duration');
-    const selectDurationInput = within(selectDurationAutoComplete).getByRole('combobox');
-    selectDurationAutoComplete.focus();
-    await fireEvent.change(selectDurationInput, {
-      target: { value: 'Monthly' },
+    const durationAutoComplete = screen.getByTestId('duration');
+    const durationInput = within(durationAutoComplete).getByRole('combobox');
+
+    // Focus and type to open dropdown
+    fireEvent.focus(durationInput);
+    fireEvent.change(durationInput, { target: { value: 'Monthly' } });
+
+    // Select the option
+    await act(async () => {
+      const option = screen.getByText('Monthly');
+      fireEvent.click(option);
     });
-    fireEvent.keyDown(selectDurationAutoComplete, { key: 'ArrowDown' });
-    await act(() => fireEvent.keyDown(selectDurationAutoComplete, { key: 'Enter' }));
 
     // Select start date
     const startDateInput = screen.getByTestId('startDate').querySelector('input');
-
     if (startDateInput) {
       await act(async () => {
-        fireEvent.input(startDateInput, { target: { value: '2024-01-01' } });
+        fireEvent.change(startDateInput, { target: { value: '2024-01-01' } });
       });
     }
 
     // End date
     const endDateInput = screen.getByTestId('endDate').querySelector('input');
-
     if (endDateInput) {
       await act(async () => {
-        fireEvent.input(endDateInput, { target: { value: '2024-02-01' } });
+        fireEvent.change(endDateInput, { target: { value: '2024-02-01' } });
       });
     }
+
     // Submit the form
-    fireEvent.click(screen.getByTestId('savebutton'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('savebutton'));
+    });
+
     // Verify the API call
     await waitFor(() => {
       expect(httpPost).toHaveBeenCalledWith(mockSession.data, 'v1/organizations/', {
         name: 'New Org',
         base_plan: 'Dalgo',
-        email: '',
         subscription_duration: 'Monthly',
         can_upgrade_plan: false,
         superset_included: true,
@@ -169,7 +221,7 @@ describe('CreateOrgForm Component', () => {
 
     // Verify form cleanup and navigation
     await waitFor(() => {
-      expect(localStorage.getItem('org-slug')).toBe('new-org-slug');
+      expect(localStorageMock.setItem).toHaveBeenCalledWith('org-slug', 'new-org-slug');
       expect(closeSideMenu).toHaveBeenCalled();
       expect(setShowForm).toHaveBeenCalledWith(false);
       expect(successToast).toHaveBeenCalledWith(
@@ -180,89 +232,86 @@ describe('CreateOrgForm Component', () => {
     });
   });
 
-  it('submits the form correctly and handles the response when trial is free trial', async () => {
+  it('submits the form correctly for Free Trial plan', async () => {
+    const user = userEvent.setup();
     const closeSideMenu = jest.fn();
     const setShowForm = jest.fn();
     // Mock the response for httpPost
-    (httpPost as jest.Mock).mockResolvedValueOnce({ slug: 'new-org-slug' });
+    (httpPost as jest.Mock).mockResolvedValueOnce({ task_id: 'task-123' });
 
-    // Render the component
     renderComponent({ closeSideMenu, setShowForm });
 
     // Fill in the organization name
     const inputOrgDiv = screen.getByTestId('input-orgname');
     const inputOrg = within(inputOrgDiv).getByRole('textbox');
-    fireEvent.change(inputOrg, { target: { value: 'New Org' } });
+    await user.type(inputOrg, 'New Org');
 
-    // Select Free Trial plan - using the more reliable way
-    const basePlanAutoComplete = screen.getByTestId('baseplan');
-    const basePlanTextInput = within(basePlanAutoComplete).getByRole('combobox');
+    // Select Free Trial plan
+    const basePlanDiv = screen.getByTestId('baseplan');
+    const basePlanInput = within(basePlanDiv).getByRole('combobox');
+    await user.click(basePlanInput);
+    await user.type(basePlanInput, 'Free Trial');
+    const freeTrial = screen.getByText('Free Trial');
+    await user.click(freeTrial);
 
-    // Open dropdown and select Free Trial
-    await act(async () => {
-      basePlanAutoComplete.focus();
-      fireEvent.change(basePlanTextInput, { target: { value: 'Free Trial' } });
-      fireEvent.keyDown(basePlanAutoComplete, { key: 'ArrowDown' });
-      fireEvent.keyDown(basePlanAutoComplete, { key: 'Enter' });
-    });
+    // Fill in email
+    const emailInput = within(screen.getByTestId('input-email')).getByRole('textbox');
+    await user.type(emailInput, 'test@example.com');
 
-    // Wait for and fill in email input that should appear
-    await waitFor(() => {
-      const inputEmailDiv = screen.getByTestId('input-email');
-      const inputEmail = within(inputEmailDiv).getByRole('textbox');
-      fireEvent.change(inputEmail, { target: { value: 'test@example.com' } });
-    });
+    // Fill in superset EC2 machine ID
+    const supersetEc2Input = within(screen.getByTestId('input-superset_ec2_machine_id')).getByRole(
+      'textbox'
+    );
+    await user.type(supersetEc2Input, 'i-1234567890abcdef0');
+
+    // Fill in superset port
+    const supersetPortInput = within(screen.getByTestId('input-superset_port')).getByRole(
+      'spinbutton'
+    );
+    await user.type(supersetPortInput, '8080');
 
     // Select superset included
-    const supersetIncludedAutoComplete = screen.getByTestId('superset_included');
-    const supersetIncludedValue = within(supersetIncludedAutoComplete).getByRole('combobox');
-    await act(async () => {
-      supersetIncludedAutoComplete.focus();
-      fireEvent.change(supersetIncludedValue, { target: { value: 'Yes' } });
-      fireEvent.keyDown(supersetIncludedAutoComplete, { key: 'ArrowDown' });
-      fireEvent.keyDown(supersetIncludedAutoComplete, { key: 'Enter' });
-    });
-
-    // Note: Duration should automatically be set to 'Trial' for Free Trial plan
+    const supersetIncludedDiv = screen.getByTestId('superset_included');
+    const supersetIncludedInput = within(supersetIncludedDiv).getByRole('combobox');
+    await user.click(supersetIncludedInput);
+    await user.type(supersetIncludedInput, 'Yes');
+    const yesOption = screen.getByText('Yes');
+    await user.click(yesOption);
 
     // Select start date
     const startDateInput = screen.getByTestId('startDate').querySelector('input');
     if (startDateInput) {
-      await act(async () => {
-        fireEvent.input(startDateInput, { target: { value: '2024-01-01' } });
-      });
+      await user.type(startDateInput, '2024-01-01');
     }
 
     // End date
     const endDateInput = screen.getByTestId('endDate').querySelector('input');
     if (endDateInput) {
-      await act(async () => {
-        fireEvent.input(endDateInput, { target: { value: '2024-02-01' } });
-      });
+      await user.type(endDateInput, '2024-02-01');
     }
 
     // Submit the form
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('savebutton'));
-    });
+    const submitButton = screen.getByTestId('savebutton');
+    await user.click(submitButton);
 
     // Verify the API call with correct Free Trial values
     await waitFor(() => {
-      expect(httpPost).toHaveBeenCalledWith(mockSession.data, 'v1/organizations/', {
+      expect(httpPost).toHaveBeenCalledWith(mockSession.data, 'v1/organizations/free_trial', {
         name: 'New Org',
         base_plan: 'Free Trial',
-        email: 'test@example.com',
         subscription_duration: 'Trial',
         can_upgrade_plan: true,
         superset_included: true,
         start_date: '2024-01-01T00:00:00.000Z',
         end_date: '2024-02-01T00:00:00.000Z',
+        superset_ec2_machine_id: 'i-1234567890abcdef0',
+        superset_port: '8080',
+        email: 'test@example.com',
       });
     });
 
     // Verify form cleanup and navigation
     await waitFor(() => {
-      expect(localStorage.getItem('org-slug')).toBe('new-org-slug');
       expect(closeSideMenu).toHaveBeenCalled();
       expect(setShowForm).toHaveBeenCalledWith(false);
       expect(successToast).toHaveBeenCalledWith(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The organization creation form now includes additional fields for email, superset EC2 machine ID, and superset port, which are displayed when the Free Trial plan is selected. The form validates the email input and provides error feedback if required information is missing, enhancing the registration experience.
  
- **Tests**
  - Enhanced testing for the organization creation form, including a new test case for form submission with the Free Trial plan, ensuring correct API call parameters.

- **Chores**
  - Added `.qodo` to the `.gitignore` file to prevent tracking of specific files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->