### PR TITLE
update the schedule after updating the deployment

### DIFF
--- a/src/components/Flows/FlowCreate.tsx
+++ b/src/components/Flows/FlowCreate.tsx
@@ -257,15 +257,6 @@ const FlowCreate = ({
       }));
       if (isEditPage) {
         setLoading(true);
-        // hit the set schedule api if the value is updated
-        if (dirtyFields?.active) {
-          await httpPost(
-            session,
-            `prefect/flows/${flowId}/set_schedule/${data.active ? 'active' : 'inactive'}`,
-            {}
-          );
-        }
-
         // hit the update deplyment api if the cron is updated
         await httpPut(session, `prefect/v1/flows/${flowId}`, {
           cron: cronExpression,
@@ -276,6 +267,15 @@ const FlowCreate = ({
             seq: index + 1,
           })),
         });
+        // hit the set schedule api if the value is updated
+        if (dirtyFields?.active) {
+          await httpPost(
+            session,
+            `prefect/flows/${flowId}/set_schedule/${data.active ? 'active' : 'inactive'}`,
+            {}
+          );
+        }
+
         successToast(`Pipeline ${data.name} updated successfully`, [], toastContext);
         setSelectedFlowId('');
       } else {


### PR DESCRIPTION
We have been updating the schedule before the deployment, and the second update undoes the first

when we update an orchestration pipeline to make it inactive, we call two apis from `FlowCreate.tsx:261-278`:
1. `prefect/flows/${flowId}/set_schedule/`
2. `prefect/v1/flows/${flowId}`

the first one updates the schedule, no problem. 

but then the second one resets it:

`pipeline_api.put_prefect_dataflow_v1:494` 
calls 
`prefect_service.update_dataflow_v1` 
which calls 
`v1/deployments/{deployment_id}` on the proxy 
which comes to `service.put_deployment_v1` 
which does
```
    newpayload["schedules"] = (
        [{"schedule": CronSchedule(cron=payload.cron).model_dump(), "active": True}]
        if payload.cron
        else []
    )
```
 thereby setting to active again

the short-term fix is to reverse the order of the api calls (1) and (20
