### PR TITLE
Optimized re-rendering of Connections Page Data

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,5 +77,6 @@
   },
   "engines": {
     "node": ">=18.17.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -23,6 +23,10 @@ interface ListProps {
   rowValues?: Array<Array<any>>;
 }
 
+interface ListComponentProps extends Pick<ListProps, 'headers' | 'height'> {
+  row: any;
+}
+
 export const List = ({
   title,
   openDialog,
@@ -106,36 +110,7 @@ export const List = ({
             </TableHead>
             <TableBody>
               {orderedRows.map((row: any, idx: number) => (
-                <TableRow
-                  key={idx}
-                  sx={{
-                    '&:last-child td, &:last-child th': { border: 0 },
-                    ...(height && { height }),
-                  }}
-                >
-                  {row.map(
-                    // if action is sent render with right align
-                    (column: any, idx: number) => (
-                      <TableCell
-                        key={idx}
-                        align={
-                          headers.values.length + 1 === row.length && idx === row.length - 1
-                            ? 'right'
-                            : 'left'
-                        }
-                      >
-                        {column}
-                      </TableCell>
-                    )
-                  )}
-                  {headers.values.length + 1 !== row.length ? ( // if actions is not sent render some text
-                    <TableCell sx={{ p: 1 }} align="right">
-                      Actions
-                    </TableCell>
-                  ) : (
-                    ''
-                  )}
-                </TableRow>
+                <ListComponent key={idx} row={row} height={height} headers={headers} />
               ))}
             </TableBody>
           </Table>
@@ -148,3 +123,39 @@ export const List = ({
     </>
   );
 };
+
+const ListComponent = React.memo(function ListComponent({
+  row,
+  height,
+  headers,
+}: ListComponentProps) {
+  return (
+    <TableRow
+      sx={{
+        '&:last-child td, &:last-child th': { border: 0 },
+        ...(height && { height }),
+      }}
+    >
+      {row.map(
+        // if action is sent render with right align
+        (column: any, idx: number) => (
+          <TableCell
+            key={idx}
+            align={
+              headers.values.length + 1 === row.length && idx === row.length - 1 ? 'right' : 'left'
+            }
+          >
+            {column}
+          </TableCell>
+        )
+      )}
+      {headers.values.length + 1 !== row.length ? ( // if actions is not sent render some text
+        <TableCell sx={{ p: 1 }} align="right">
+          Actions
+        </TableCell>
+      ) : (
+        ''
+      )}
+    </TableRow>
+  );
+});


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/DalgoT4D/webapp) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Please ensure coding standard and conventions are followed.

-->

## Summary
Fixed Issue #1454 
This PR aims to optimize the re-rendering process of Connections Page. I refactored the Connection Rows which could be memoized into another function. I used React.memo to optimize the rendering.

I could not test if this optimizes the rendering in action as I was using the deployed backend, and because of the guest role I could not test the 'Sync' button on the Connections Page. I request a reviewer to check if it solves re-rendering(which it does probably), before merging.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
-
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
