### PR TITLE
Hiding the elementary page if the transform_type is ui4t

### DIFF
--- a/src/components/SideDrawer/SideDrawer.tsx
+++ b/src/components/SideDrawer/SideDrawer.tsx
@@ -12,6 +12,7 @@ import {
   Link,
   Typography,
   Tooltip,
+  CircularProgress,
 } from '@mui/material';
 import MuiDrawer from '@mui/material/Drawer';
 import { styled, Theme, CSSObject } from '@mui/material/styles';
@@ -23,6 +24,8 @@ import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import { ProductWalk } from '../ProductWalk/ProductWalk';
 import { GlobalContext } from '@/contexts/ContextProvider';
 import { demoProductWalkthrough } from '@/config/constant';
+import { fetchTransformType, TransformType } from '@/pages/pipeline/transform';
+import { useSession } from 'next-auth/react';
 
 export interface ItemButtonProps {
   openMenu: boolean;
@@ -123,11 +126,14 @@ const Drawer = styled(MuiDrawer, {
 export const SideDrawer = ({ openMenu, setOpenMenu }: any) => {
   const router = useRouter();
   const globalContext = useContext(GlobalContext);
-  const sideMenu: MenuOption[] = getSideMenu();
+  const { data: session } = useSession();
+  const [transformType, setTransformType] = useState<any>('');
+  const sideMenu: MenuOption[] = getSideMenu({ transformType });
   const { state } = globalContext?.UnsavedChanges ?? {};
   const [open, setOpen] = useState(
     new Array(sideMenu.filter((item) => !item.parent).length).fill(false)
   );
+  const [loading, setLoading] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(
     sideMenu.find((item) => item.path === router.pathname)?.index
   );
@@ -182,6 +188,17 @@ export const SideDrawer = ({ openMenu, setOpenMenu }: any) => {
       }
     }
   }, [openMenu]);
+
+  useEffect(() => {
+    if (!session) return;
+    const getTransformType = async () => {
+      setLoading(true);
+      const { transform_type } = await fetchTransformType(session);
+      setTransformType(transform_type);
+      setLoading(false);
+    };
+    getTransformType();
+  }, [session]);
 
   useEffect(() => {
     setRunWalkThrough(true);
@@ -280,7 +297,7 @@ export const SideDrawer = ({ openMenu, setOpenMenu }: any) => {
       open={openMenu}
       variant="permanent"
     >
-      {getList}
+      {loading ? <CircularProgress /> : getList}
       {openMenu && (
         <Box
           sx={{

--- a/src/components/SideDrawer/__tests__/SideDrawer.test.tsx
+++ b/src/components/SideDrawer/__tests__/SideDrawer.test.tsx
@@ -1,10 +1,23 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
 import { GlobalContext } from '@/contexts/ContextProvider';
 import { SideDrawer } from '../SideDrawer';
 import { getSideMenu } from '@/config/menu';
 import { useRouter } from 'next/router';
-const sideMenu = getSideMenu();
+import { SessionProvider } from 'next-auth/react';
+
+// Mock ProductWalk component
+jest.mock('../../ProductWalk/ProductWalk', () => ({
+  ProductWalk: () => <div data-testid="mocked-product-walk" />,
+}));
+
+// Mock fetchTransformType from pipeline transform
+const mockFetchTransformType = jest.fn().mockResolvedValue({ transform_type: 'ui' });
+jest.mock('@/pages/pipeline/transform', () => ({
+  fetchTransformType: jest.fn().mockImplementation(() => mockFetchTransformType()),
+}));
+
+const sideMenu = getSideMenu({ transformType: 'ui' });
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
 }));
@@ -15,20 +28,44 @@ const mockGlobalContextValue: any = {
   UnsavedChanges: { state: false },
 };
 
+// Mock session data
+const mockSession = {
+  data: {
+    user: {
+      token: 'test-token',
+      email_verified: true,
+    },
+  },
+  status: 'authenticated',
+  expires: '2023-01-01',
+};
+
 describe('SideDrawer', () => {
   const mockedUseRouter: any = useRouter;
   const setOpenMenu = jest.fn();
   const pushMock = jest.fn();
-  beforeEach(() => {
+
+  beforeEach(async () => {
     mockedUseRouter.mockReturnValue({
       pathname: '/',
       push: pushMock,
     });
-    render(
-      <GlobalContext.Provider value={mockGlobalContextValue}>
-        <SideDrawer openMenu={true} setOpenMenu={setOpenMenu} />
-      </GlobalContext.Provider>
-    );
+
+    await act(async () => {
+      render(
+        <SessionProvider session={mockSession}>
+          <GlobalContext.Provider value={mockGlobalContextValue}>
+            <SideDrawer openMenu={true} setOpenMenu={setOpenMenu} />
+          </GlobalContext.Provider>
+        </SessionProvider>
+      );
+    });
+
+    // Wait for the loading state to finish
+    await waitFor(() => {
+      expect(mockFetchTransformType).toHaveBeenCalled();
+    });
+
     const sideMenuList = screen.getByTestId('side-menu');
     expect(sideMenuList).toBeInTheDocument();
   });
@@ -36,38 +73,44 @@ describe('SideDrawer', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
+
   it('checks the side menu is defined and has menu-list', () => {
     expect(sideMenu).toBeDefined();
     expect(sideMenu.length).toBeGreaterThan(0);
   });
 
-  it('renders fixed menu-itmes correctly', () => {
-    const documentationLink = screen.getByTestId('documentation');
+  it('renders fixed menu-items correctly', async () => {
+    const documentationLink = await screen.findByTestId('documentation');
     expect(documentationLink).toBeInTheDocument();
 
-    const privacyPolicyLink = screen.getByTestId('privacypolicy');
+    const privacyPolicyLink = await screen.findByTestId('privacypolicy');
     expect(privacyPolicyLink).toBeInTheDocument();
   });
 
-  it('should render all side menu items which are not hidden', () => {
-    sideMenu
-      .filter((item) => !item.hide && item.parent === undefined)
-      .forEach((item) => {
-        if (item.index) {
-          const menuItem = screen.getByTestId(`menu-item-${item.index}`);
-          expect(menuItem).toBeInTheDocument();
-        }
-      });
+  it('should render all side menu items which are not hidden', async () => {
+    await waitFor(() => {
+      sideMenu
+        .filter((item) => !item.hide && item.parent === undefined)
+        .forEach((item) => {
+          if (item.index) {
+            const menuItem = screen.getByTestId(`menu-item-${item.index}`);
+            expect(menuItem).toBeInTheDocument();
+          }
+        });
+    });
   });
 
   it('should handle menu item click and navigation', async () => {
     const itemToTest = sideMenu.find((item) => item.path === '/pipeline');
     if (itemToTest && !itemToTest.hide) {
-      const menuItem = screen.getByTestId(`menu-item-1`);
+      const menuItem = await screen.findByTestId(`menu-item-1`);
       expect(menuItem).toBeInTheDocument();
       const menuLink = within(menuItem).getByTestId('listButton');
       expect(menuLink).toBeInTheDocument();
-      fireEvent.click(menuLink);
+
+      await act(async () => {
+        fireEvent.click(menuLink);
+      });
 
       await waitFor(() => {
         expect(pushMock).toHaveBeenCalledWith('/pipeline');
@@ -76,13 +119,16 @@ describe('SideDrawer', () => {
   });
 
   it('should render child items when expanded or vice versa', async () => {
-    const toggleSwitch = screen.getByTestId(`expand-toggle-1`);
+    const toggleSwitch = await screen.findByTestId(`expand-toggle-1`);
     expect(toggleSwitch).toBeInTheDocument();
 
     expect(screen.queryByTestId('menu-item-1.1')).not.toBeInTheDocument();
     expect(screen.queryByTestId('menu-item-1.2')).not.toBeInTheDocument();
     expect(screen.queryByTestId('menu-item-1.3')).not.toBeInTheDocument();
-    fireEvent.click(toggleSwitch);
+
+    await act(async () => {
+      fireEvent.click(toggleSwitch);
+    });
 
     await waitFor(() => {
       expect(screen.queryByTestId('menu-item-1.1')).toBeInTheDocument();
@@ -97,10 +143,12 @@ describe('SideDrawer', () => {
       expect(minimizedMenu).toBeDefined();
 
       if (minimizedMenu) {
-        const menuItem = screen.getByTestId(`menu-item-${minimizedMenu.index}`);
-
+        const menuItem = await screen.findByTestId(`menu-item-${minimizedMenu.index}`);
         const menuList = within(menuItem).getByTestId(`listButton`);
-        fireEvent.click(menuList);
+
+        await act(async () => {
+          fireEvent.click(menuList);
+        });
 
         expect(setOpenMenu).toHaveBeenCalledWith(false);
       }

--- a/src/config/menu.tsx
+++ b/src/config/menu.tsx
@@ -17,11 +17,12 @@ import {
   showSupersetAnalysisTab,
   showSupersetUsageTab,
 } from './constant';
+import { fetchTransformType } from '@/pages/pipeline/transform';
 export const drawerWidth = 250;
 
 const getColor = (selected: boolean) => (selected ? primaryColor : '');
 
-export const getSideMenu = () => {
+export const getSideMenu = ({ transformType }: { transformType: string }) => {
   return [
     // This will be added at a later stage
     {
@@ -98,7 +99,7 @@ export const getSideMenu = () => {
       path: '/data-quality',
       icon: (selected: boolean) => <DataQualityIcon fill={getColor(selected)} />,
       className: 'data_quality_walkthrough',
-      hide: !showElementaryMenu,
+      hide: !showElementaryMenu || transformType === 'ui',
       minimize: false,
     },
     {

--- a/src/pages/pipeline/transform.tsx
+++ b/src/pages/pipeline/transform.tsx
@@ -19,6 +19,17 @@ interface TransformTypeResponse {
   transform_type: TransformType;
 }
 
+export const fetchTransformType = async (session: any) => {
+  try {
+    const { transform_type } = await httpGet(session, 'dbt/dbt_transform/');
+
+    return { transform_type: transform_type as TransformType };
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
 const Transform = () => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [confirmationOpen, setConfirmationOpen] = useState<boolean>(false);
@@ -40,19 +51,8 @@ const Transform = () => {
   };
 
   useEffect(() => {
-    const fetchTransformType = async () => {
-      try {
-        const { transform_type } = await httpGet(session, 'dbt/dbt_transform/');
-
-        return { transform_type: transform_type as TransformType };
-      } catch (error) {
-        console.error(error);
-        throw error;
-      }
-    };
-
     if (session) {
-      fetchTransformType()
+      fetchTransformType(session)
         .then((response: TransformTypeResponse) => {
           const transformType = response.transform_type;
           if (transformType === 'ui' || transformType === 'github')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The side drawer now displays a loading indicator during data retrieval, providing clearer user feedback.
	- The side menu adapts dynamically based on the current session and transformation type, with certain menu options (like “Data Quality”) conditionally hidden for a streamlined experience.

- **Bug Fixes**
	- Improved handling of asynchronous operations in the testing setup for the side drawer component, ensuring accurate test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->