### PR TITLE
Refactored Code for Actions Menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,5 +77,6 @@
   },
   "engines": {
     "node": ">=18.17.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/components/Connections/Connections.tsx
+++ b/src/components/Connections/Connections.tsx
@@ -549,11 +549,8 @@ export const Connections = () => {
     setClearConnDeploymentId(connection.clearConnDeploymentId);
     setAnchorEl(event);
   };
-  const handleClose = (isEditMode?: string) => {
-    if (isEditMode !== 'EDIT') {
-      setConnectionId('');
-      setClearConnDeploymentId('');
-    }
+  const handleClose = () => {
+    setConnectionId('');
     setAnchorEl(null);
   };
   const [showDialog, setShowDialog] = useState(false);
@@ -751,7 +748,7 @@ export const Connections = () => {
   };
 
   const handleDeleteConnection = () => {
-    handleClose('EDIT');
+    handleClose();
     setShowConfirmDeleteDialog(true);
   };
 
@@ -764,13 +761,12 @@ export const Connections = () => {
   };
 
   const handleClearConnection = () => {
-    handleClose('EDIT');
+    handleClose();
     setShowConfirmResetDialog(true);
     trackAmplitudeEvent('[Reset-connection] Button Clicked');
   };
 
   const handleEditConnection = () => {
-    handleClose('EDIT');
     setShowDialog(true);
   };
 
@@ -836,6 +832,7 @@ export const Connections = () => {
         mutate={mutate}
         showForm={showDialog}
         setShowForm={setShowDialog}
+        closeActionMenu={handleClose}
       />
       <List
         hasCreatePermission={permissions.includes('can_create_connection')}

--- a/src/components/Connections/CreateConnectionForm.tsx
+++ b/src/components/Connections/CreateConnectionForm.tsx
@@ -28,6 +28,7 @@ interface CreateConnectionFormProps {
   showForm: boolean;
   setShowForm: (...args: any) => any;
   setConnectionId: (...args: any) => any;
+  closeActionMenu: (...args: any) => any;
 }
 
 type CursorFieldConfig = {
@@ -57,6 +58,7 @@ const CreateConnectionForm = ({
   mutate,
   showForm,
   setShowForm,
+  closeActionMenu,
 }: CreateConnectionFormProps) => {
   const { data: session }: any = useSession();
   const globalContext = useContext(GlobalContext);
@@ -257,6 +259,7 @@ const CreateConnectionForm = ({
   const handleClose = () => {
     reset();
     setConnectionId('');
+    closeActionMenu();
     setSourceStreams([]);
     setFilteredSourceStreams([]);
     setShowForm(false);
@@ -304,6 +307,8 @@ const CreateConnectionForm = ({
     } catch (err: any) {
       console.error(err);
       errorToast(err.message, [], globalContext);
+    } finally {
+      closeActionMenu();
     }
     setLoading(false);
   };

--- a/src/components/Connections/__tests__/CreateConnection.test.tsx
+++ b/src/components/Connections/__tests__/CreateConnection.test.tsx
@@ -96,6 +96,7 @@ describe('Create connection', () => {
             setConnectionId={() => {}}
             blockId=""
             filteredSourceStreams={[]}
+            closeActionMenu={() => {}}
           />
         </SessionProvider>
       );
@@ -127,6 +128,7 @@ describe('Create connection', () => {
           setShowForm={() => {}}
           blockId=""
           setBlockId={() => {}}
+          closeActionMenu={() => {}}
         />
       </SessionProvider>
     );
@@ -203,6 +205,7 @@ describe('Create connection', () => {
               setConnectionId={() => {}}
               blockId=""
               filteredSourceStreams={[]}
+              closeActionMenu={() => {}}
             />
           </SWRConfig>
         </SessionProvider>

--- a/src/components/Connections/__tests__/CreateConnection.test.tsx
+++ b/src/components/Connections/__tests__/CreateConnection.test.tsx
@@ -306,6 +306,7 @@ describe('Create connection', () => {
               connectionId=""
               setConnectionId={() => {}}
               blockId=""
+              closeActionMenu={() => {}}
             />
           </SWRConfig>
         </SessionProvider>
@@ -418,6 +419,7 @@ describe('Create connection', () => {
               connectionId=""
               setConnectionId={() => {}}
               blockId=""
+              closeActionMenu={() => {}}
             />
           </SWRConfig>
         </SessionProvider>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/DalgoT4D/webapp) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Please ensure coding standard and conventions are followed.

-->

## Summary
Fixes #1455 
Instead of moving the API call, I set connectionId("") whenever handleClose() is called. As this causes the edit form to reset as well, I moved the handleClose() function call, which now gets called when the Edit form is exited / submitted. It isn't triggered before the Edit Form appears. This easily tackles the issue.
Now when New Connection button is clicked, the form is empty.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


[Screencast from 2025-04-10 05-52-48.webm](https://github.com/user-attachments/assets/70e63b49-986c-4af6-972b-af90af7a3ced)

## Test Plan
Modified test cases in `src/components/Connections/__tests__/CreateConnection.test.tsx`<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Updated project configuration by adding package manager metadata.

- **Refactor**
  - Streamlined connection closing behavior for more consistent state management.

- **New Features**
  - Enhanced the form’s interaction by ensuring the action menu reliably closes during submission and cancellation.
  - Introduced a new property to manage closing the action menu in the CreateConnectionForm component.
  - Added support for the new `closeActionMenu` prop in the CreateConnectionForm component's tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->