### PR TITLE
Fix: Ensure Newly Invited Users Appear Immediately in Pending Invitations Tab

### DIFF
--- a/src/components/Invitations/__tests__/InviteUserForm.test.tsx
+++ b/src/components/Invitations/__tests__/InviteUserForm.test.tsx
@@ -114,4 +114,51 @@ describe('Invite user', () => {
 
     expect(inviteUserApiMock).toHaveBeenCalledTimes(1);
   });
+
+  it('calls setMutateInvitationsParent after a successful invitation', async () => {
+    const inviteUserApiMock = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValueOnce({ success: 1 }),
+    });
+
+    global.fetch = inviteUserApiMock;
+
+    const setMutateInvitationsParent = jest.fn();
+
+    const inviteForm = (
+      <SWRConfig
+        value={{
+          dedupingInterval: 0,
+          fetcher: (resource) => mockRoles(resource, {}).then((res: any) => res.json()),
+          provider: () => new Map(),
+        }}
+      >
+        <SessionProvider session={mockSession}>
+          <InviteUserForm
+            mutate={mutate}
+            showForm={true}
+            setShowForm={setShowForm}
+            setMutateInvitationsParent={setMutateInvitationsParent}
+          />
+        </SessionProvider>
+      </SWRConfig>
+    );
+
+    render(inviteForm);
+
+    const emailInput = screen.getByLabelText('Email*');
+    await user.type(emailInput, 'inviteuser@gmail.com');
+
+    const dropdown = screen.getByRole('combobox');
+    await user.click(dropdown);
+
+    const firstOption = screen.getAllByRole('option')[0];
+    await user.click(firstOption);
+
+    const savebutton = screen.getByTestId('savebutton');
+    await userEvent.click(savebutton);
+
+    expect(inviteUserApiMock).toHaveBeenCalledTimes(1);
+    expect(setMutateInvitationsParent).toHaveBeenCalledWith(true);
+  });
 });


### PR DESCRIPTION
issue Reference: Fixes #1483 
**Description**
This pull request addresses an issue where newly invited users do not appear immediately in the "Pending Invitations" tab after sending an invitation. The changes ensure that the data is refreshed automatically, providing a seamless user experience.

**Changes Made**

**1. Code changes** 

- Updated the [InviteUserForm](https://reimagined-eureka-g4qprwpx9gpv3w9wg.github.dev/) component to trigger a data refresh ([setMutateInvitationsParent](https://reimagined-eureka-g4qprwpx9gpv3w9wg.github.dev/)) after a successful invitation.
- Added proper TypeScript types to replace `any` in the [InviteUserForm](https://reimagined-eureka-g4qprwpx9gpv3w9wg.github.dev/) component for better type safety and maintainability.

**2. Test Coverage:**

- Added a Jest test in [InviteUserForm.test.tsx](https://reimagined-eureka-g4qprwpx9gpv3w9wg.github.dev/) to verify that [setMutateInvitationsParent](https://reimagined-eureka-g4qprwpx9gpv3w9wg.github.dev/) is called after a successful invitation.
- Ensured all existing tests pass successfully.

**Tests Run**
Jest Tests: All unit tests were executed, and no tests failed.
Cypress Tests: End-to-end tests were run to ensure no regressions in functionality.

**Acceptance Criteria**
Newly invited users appear immediately in the "Pending Invitations" tab.
All Jest and Cypress tests pass successfully.