### PR TITLE
send the sync catalog and the catalog id back

### DIFF
--- a/src/components/Connections/CreateConnectionForm.tsx
+++ b/src/components/Connections/CreateConnectionForm.tsx
@@ -68,6 +68,8 @@ const CreateConnectionForm = ({
       sources: { label: '', id: '' },
       destinations: { label: '', id: '' },
       destinationSchema: globalContext?.CurrentOrg.state.is_demo ? demoAccDestSchema : 'staging',
+      syncCatalog: { streams: [] }, // send the catalog back as is so backend doesn't need to do another discover schema call
+      catalogId: '', // send the catalogId back as is to the backend
     },
   });
   const [sources, setSources] = useState<Array<string>>([]);
@@ -178,6 +180,8 @@ const CreateConnectionForm = ({
             id: data?.source.id,
           });
           setValue('destinationSchema', data?.destinationSchema);
+          setValue('syncCatalog', data?.syncCatalog);
+          setValue('catalogId', data?.catalogId);
           const streams = setupInitialStreamsState(data?.syncCatalog, connectionId);
           setSourceStreams(streams);
           setFilteredSourceStreams(streams);
@@ -243,11 +247,14 @@ const CreateConnectionForm = ({
 
     const { data, message, status } = lastJsonMessage;
     const source_schema_catalog = data?.result?.catalog;
+    const catalogId = data?.result?.catalogId;
 
     if (status == 'success' && source_schema_catalog) {
       const streams: SourceStream[] = setupInitialStreamsState(source_schema_catalog, connectionId);
       setSourceStreams(streams);
       setFilteredSourceStreams(streams);
+      setValue('syncCatalog', source_schema_catalog); // this will be sent back as is to backend so that backend doesn't need to do another discover schema call
+      setValue('catalogId', catalogId);
     } else if (status == 'error') {
       setSourceStreams([]);
       setFilteredSourceStreams([]);
@@ -286,6 +293,8 @@ const CreateConnectionForm = ({
         };
       }),
       normalize,
+      syncCatalog: data.syncCatalog,
+      catalogId: data.catalogId,
     };
     if (data.destinationSchema) {
       payload.destinationSchema = data.destinationSchema;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The connection creation form now preserves and submits catalog information, including the catalog identifier, improving the handling of schema catalogs during connection setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->