### PR TITLE
sort connections by name

### DIFF
--- a/src/components/Connections/Connections.tsx
+++ b/src/components/Connections/Connections.tsx
@@ -687,7 +687,11 @@ export const Connections = () => {
 
   const updateRows = (data: any) => {
     if (data && data.length > 0) {
-      const tempRows = data.map((connection: any) => [
+      // Sort connections alphabetically by name (case-insensitive)
+      const sortedData = [...data].sort((a, b) =>
+        a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+      );
+      const tempRows = sortedData.map((connection: any) => [
         <Box key={`name-${connection.blockId}`} sx={{ display: 'flex', alignItems: 'center' }}>
           <Image style={{ marginRight: 10 }} src={connectionIcon} alt="dbt icon" />
           <Typography variant="body1" fontWeight={600}>
@@ -716,7 +720,7 @@ export const Connections = () => {
         />,
       ]);
 
-      const tempRowValues = data.map((connection: any) => [connection.name, null, null]);
+      const tempRowValues = sortedData.map((connection: any) => [connection.name, null, null]);
 
       setRows(tempRows);
       setRowValues(tempRowValues);
@@ -768,7 +772,11 @@ export const Connections = () => {
           conn.destination?.destinationName?.toLowerCase().includes(lower)
         );
       });
-      updateRows(filtered);
+      // Sort filtered results by name
+      const sortedFiltered = [...filtered].sort((a, b) =>
+        a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+      );
+      updateRows(sortedFiltered);
     }
   };
 

--- a/src/components/Connections/Connections.tsx
+++ b/src/components/Connections/Connections.tsx
@@ -685,12 +685,19 @@ export const Connections = () => {
     handleCancelClearConnection();
   };
 
+  const sortingConnections = (data: any[]) => {
+    if (!data || data.length === 0) return [];
+    const sortedData = [...data].sort((a, b) =>
+      a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+    );
+    return sortedData;
+  };
+
   const updateRows = (data: any) => {
     if (data && data.length > 0) {
       // Sort connections alphabetically by name (case-insensitive)
-      const sortedData = [...data].sort((a, b) =>
-        a.name.toLowerCase().localeCompare(b.name.toLowerCase())
-      );
+      const sortedData = sortingConnections(data);
+
       const tempRows = sortedData.map((connection: any) => [
         <Box key={`name-${connection.blockId}`} sx={{ display: 'flex', alignItems: 'center' }}>
           <Image style={{ marginRight: 10 }} src={connectionIcon} alt="dbt icon" />
@@ -773,9 +780,8 @@ export const Connections = () => {
         );
       });
       // Sort filtered results by name
-      const sortedFiltered = [...filtered].sort((a, b) =>
-        a.name.toLowerCase().localeCompare(b.name.toLowerCase())
-      );
+      const sortedFiltered = sortingConnections(filtered);
+
       updateRows(sortedFiltered);
     }
   };


### PR DESCRIPTION
Sort connections by name, courtesy of GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Connection entries are now consistently displayed in alphabetical order, both initially and after using the search feature. Sorting is case-insensitive for improved usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->