### PR TITLE
View history bug fixed

### DIFF
--- a/src/components/Connections/Connections.tsx
+++ b/src/components/Connections/Connections.tsx
@@ -88,6 +88,7 @@ export type Connection = {
   resetConnDeploymentId: string | null;
   clearConnDeploymentId: string | null;
   queuedFlowRunWaitTime: QueuedRuntimeInfo | null;
+  blockId: string;
 };
 // type LockStatus = 'running' | 'queued' | 'locked' | null;
 const truncateString = (input: string) => {
@@ -733,7 +734,7 @@ export const Connections = () => {
       <Actions
         key={`actions-${connection.connectionId}`}
         connection={connection}
-        idx={connection.connectionId}
+        idx={connection.blockId}
         permissions={permissions}
         syncConnection={syncConnection}
         syncingConnectionIds={syncingConnectionIds}

--- a/src/components/Connections/Connections.tsx
+++ b/src/components/Connections/Connections.tsx
@@ -753,7 +753,7 @@ export const Connections = () => {
     setRowValues(tempRowValues);
   };
 
-  const onSearchValueChange = (value: string, data: Connection[]) => {
+  const onSearchValueChange = (data: Connection[]) => {
     if (!data) return;
     updateRows(data);
   };
@@ -766,12 +766,7 @@ export const Connections = () => {
         updatedData = await httpGet(session, 'airbyte/v1/connections');
         isLocked = updatedData?.some((conn: any) => (conn.lock ? true : false));
         await delay(3000);
-
-        if (searchInputRef.current) {
-          onSearchValueChange(searchInputRef.current.value, updatedData);
-        } else {
-          updateRows(updatedData);
-        }
+        updateRows(updatedData);
       }
     } catch (error) {
       console.log(error);
@@ -884,7 +879,7 @@ export const Connections = () => {
             variant="outlined"
             size="small"
             inputRef={searchInputRef}
-            onChange={(e) => onSearchValueChange(e.target.value, data)}
+            onChange={() => onSearchValueChange(data)}
             sx={{ width: 300 }}
           />
           <Button


### PR DESCRIPTION
What to Test:

1. With the search bar empty, click on **"View History"** and **"Edit Connection"** to verify that the correct connection is displayed.
2. Repeat the above step for both the **top connection** and any other connection in the list.

3. Now, search for any connection.

4. After performing the search, click on **"View History"** and **"Edit Connection"** for the **top connection** and any other random connection to ensure the correct connection details are rendered.

If these work correctly then the issue is fixed. 
For extra check -  Run a sync of the top connection that we get after a search. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved connection list with a search feature, allowing users to filter connections by name or source name.

- **Refactor**
  - Enhanced the way connections are displayed by sorting and filtering results for a more streamlined user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->