### PR TITLE
Disabling view button if schema change already accepted

### DIFF
--- a/src/components/Connections/Connections.tsx
+++ b/src/components/Connections/Connections.tsx
@@ -562,7 +562,7 @@ export const Connections = () => {
 
   const { data, isLoading, mutate } = useSWR(`airbyte/v1/connections`, null, {
     refreshInterval: (data) => {
-      return data?.some((conn: any) => conn.lock) ? 3000 : 0;
+      return Array.isArray(data) && data.some((conn: any) => conn.lock) ? 3000 : 0;
     },
   });
 

--- a/src/components/Connections/Connections.tsx
+++ b/src/components/Connections/Connections.tsx
@@ -559,7 +559,12 @@ export const Connections = () => {
   const [rows, setRows] = useState<Array<any>>([]);
   const [rowValues, setRowValues] = useState<Array<Array<any>>>([]);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const { data, isLoading, mutate } = useSWR(`airbyte/v1/connections`);
+
+  const { data, isLoading, mutate } = useSWR(`airbyte/v1/connections`, null, {
+    refreshInterval: (data) => {
+      return data?.some((conn: any) => conn.lock) ? 3000 : 0;
+    },
+  });
 
   const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -759,28 +764,10 @@ export const Connections = () => {
     updateRows(data);
   };
 
-  const pollForConnectionsLockAndRefreshRows = async () => {
-    try {
-      let updatedData = await httpGet(session, 'airbyte/v1/connections');
-      let isLocked: boolean = updatedData?.some((conn: any) => conn.lock);
-      while (isLocked) {
-        updatedData = await httpGet(session, 'airbyte/v1/connections');
-        isLocked = updatedData?.some((conn: any) => (conn.lock ? true : false));
-        await delay(3000);
-        updateRows(updatedData);
-        // Update SWR cache so PendingActions gets fresh data too
-        mutate(updatedData, false);
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  };
-
   // when the connection list changes
   useEffect(() => {
     if (session) {
       updateRows(data);
-      pollForConnectionsLockAndRefreshRows();
     }
   }, [session, data]);
 

--- a/src/components/Connections/Connections.tsx
+++ b/src/components/Connections/Connections.tsx
@@ -768,6 +768,8 @@ export const Connections = () => {
         isLocked = updatedData?.some((conn: any) => (conn.lock ? true : false));
         await delay(3000);
         updateRows(updatedData);
+        // Update SWR cache so PendingActions gets fresh data too
+        mutate(updatedData, false);
       }
     } catch (error) {
       console.log(error);

--- a/src/components/Connections/Connections.tsx
+++ b/src/components/Connections/Connections.tsx
@@ -852,7 +852,7 @@ export const Connections = () => {
       {showLogsDialog && (
         <ConnectionSyncHistory setShowLogsDialog={setShowLogsDialog} connection={logsConnection} />
       )}
-      <PendingActionsAccordion refreshConnectionsList={mutate} />
+      <PendingActionsAccordion refreshConnectionsList={mutate} connections={data} />
       <ActionsMenu
         eleType="connection"
         anchorEl={anchorEl}

--- a/src/components/Connections/PendingActions.tsx
+++ b/src/components/Connections/PendingActions.tsx
@@ -40,7 +40,7 @@ const PendingActionButton = ({
     <Tooltip
       title={
         isDisabled
-          ? 'Schema changes cannot be accepted while connection is syncing or schema change is being processed'
+          ? 'Schema changes cannot be accepted while a connection is syncing or while other changes are being processed'
           : ''
       }
       placement="top"

--- a/src/components/Connections/PendingActions.tsx
+++ b/src/components/Connections/PendingActions.tsx
@@ -63,7 +63,6 @@ const PendingActionsAccordion = ({
   const [selectedConnectionId, setSelectedConnectionId] = useState<string>('');
   const [connectionNameMap, setConnectionNameMap] = useState<Record<string, string>>({});
   const { data: session }: any = useSession();
-  console.log(connections, 'connections');
   const handleViewClick = (connectionId: string) => {
     setSelectedConnectionId(connectionId);
     setOpenPopup(true);
@@ -150,7 +149,7 @@ const PendingActionsAccordion = ({
                   </Box>
                   <Typography variant="h6" sx={{ fontWeight: 'bold' }}></Typography>
                   <PendingActionButton
-                    key={connectionId}
+                    key={`pending-action-button-${connectionId}`}
                     connectionId={connectionId}
                     connection={connection}
                     onViewClick={handleViewClick}

--- a/src/components/Connections/PendingActions.tsx
+++ b/src/components/Connections/PendingActions.tsx
@@ -33,8 +33,8 @@ const PendingActionButton = ({
   connection: any;
   onViewClick: (connectionId: string) => void;
 }) => {
-  const { tempSyncState } = useSyncLock(connection.lock);
-  const isDisabled = tempSyncState || !!connection.lock;
+  const { tempSyncState } = useSyncLock(connection?.lock);
+  const isDisabled = tempSyncState || !!connection?.lock;
 
   return (
     <Tooltip
@@ -150,6 +150,7 @@ const PendingActionsAccordion = ({
                   </Box>
                   <Typography variant="h6" sx={{ fontWeight: 'bold' }}></Typography>
                   <PendingActionButton
+                    key={connectionId}
                     connectionId={connectionId}
                     connection={connection}
                     onViewClick={handleViewClick}

--- a/src/components/Connections/__tests__/Connections.test.tsx
+++ b/src/components/Connections/__tests__/Connections.test.tsx
@@ -265,12 +265,13 @@ describe('Connections Setup', () => {
     await userEvent.clear(searchInput);
     await userEvent.type(searchInput, 'test-conn-2');
 
-    const filteredRow = await screen.findByText('test-conn-2');
+    const table = screen.getByRole('table');
+    const filteredRow = within(table).getByText('test-conn-2');
     expect(filteredRow).toBeInTheDocument();
 
-    const rows = screen.getAllByRole('row');
+    const rows = within(table).getAllByRole('row');
     expect(rows.length).toBe(2);
-    expect(screen.queryByText('test-conn-1')).not.toBeInTheDocument();
-    expect(screen.queryByText('test-conn-3')).not.toBeInTheDocument();
+    expect(within(table).queryByText('test-conn-1')).not.toBeInTheDocument();
+    expect(within(table).queryByText('test-conn-3')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
https://jam.dev/c/5ce890ed-cba8-44a3-abe7-9f03835c2a30
Refactor includes: 
1. Users are not allowed to view the schema change 
   a. when they have already accepted a schema change and its in progress. 
   b. when a sync is running. 
   
2. Removed the manual polling with the swr polling. The swr was already being used to fetch connections. Code becomes clean and we reused the function. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The "View" button for pending actions is now conditionally disabled with a tooltip when a connection is syncing or processing, providing clearer feedback to users.

- **Improvements**
  - The connection list now updates automatically every 3 seconds if any connection is locked, ensuring more up-to-date information without manual refresh.
  - Enhanced user interface control for pending actions based on the current connection state.
  - Improved search filtering in the connections table by scoping queries within the table for more accurate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->