### PR TITLE
Configuration viewable when connection is running

### DIFF
--- a/src/components/Connections/Connections.tsx
+++ b/src/components/Connections/Connections.tsx
@@ -379,7 +379,7 @@ const Actions = memo(
           key={'menu-' + idx}
           color="info"
           sx={{ p: 0, minWidth: 32 }}
-          disabled={tempSyncState || lock ? true : false}
+          // disabled={tempSyncState || lock ? true : false}
         >
           <MoreHorizIcon />
         </Button>
@@ -542,10 +542,15 @@ export const Connections = () => {
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
+  const [currentConnectionSyncState, setCurrentConnectionSyncState] = useState(false);
+
   const handleClick = (connection: Connection, event: HTMLElement | null) => {
     setConnectionId(connection.connectionId);
     setClearConnDeploymentId(connection.clearConnDeploymentId);
     setAnchorEl(event);
+    const isSyncRunning =
+      !!connection.lock || syncingConnectionIds.includes(connection.connectionId);
+    setCurrentConnectionSyncState(isSyncRunning);
   };
   const handleClose = (isEditMode?: string) => {
     if (isEditMode !== 'EDIT') {
@@ -800,6 +805,11 @@ export const Connections = () => {
     setShowDialog(true);
   };
 
+  const handleViewConnection = () => {
+    handleClose('EDIT');
+    setShowDialog(true);
+  };
+
   const RefreshConnection = async () => {
     handleClose();
     setIsRefreshing(true); // Set loading state to true
@@ -852,9 +862,11 @@ export const Connections = () => {
         handleRefresh={RefreshConnection}
         handleDelete={handleDeleteConnection}
         handleClearConnection={handleClearConnection}
+        handleView={handleViewConnection}
         hasResetPermission={permissions.includes('can_reset_connection')}
         hasDeletePermission={permissions.includes('can_delete_connection')}
         hasEditPermission={permissions.includes('can_edit_connection')}
+        isSyncRunning={currentConnectionSyncState}
       />
       <CreateConnectionForm
         setConnectionId={setConnectionId}
@@ -862,6 +874,7 @@ export const Connections = () => {
         mutate={mutate}
         showForm={showDialog}
         setShowForm={setShowDialog}
+        readonly={currentConnectionSyncState}
       />
       <Box>
         <Box display="flex" justifyContent="space-between" mb={1}>

--- a/src/components/Connections/Connections.tsx
+++ b/src/components/Connections/Connections.tsx
@@ -379,7 +379,7 @@ const Actions = memo(
           key={'menu-' + idx}
           color="info"
           sx={{ p: 0, minWidth: 32 }}
-          // disabled={tempSyncState || lock ? true : false}
+          disabled={tempSyncState && !lock}
         >
           <MoreHorizIcon />
         </Button>
@@ -866,7 +866,7 @@ export const Connections = () => {
         hasResetPermission={permissions.includes('can_reset_connection')}
         hasDeletePermission={permissions.includes('can_delete_connection')}
         hasEditPermission={permissions.includes('can_edit_connection')}
-        isSyncRunning={currentConnectionSyncState}
+        viewMode={currentConnectionSyncState}
       />
       <CreateConnectionForm
         setConnectionId={setConnectionId}

--- a/src/components/Connections/CreateConnectionForm.tsx
+++ b/src/components/Connections/CreateConnectionForm.tsx
@@ -564,7 +564,7 @@ const CreateConnectionForm = ({
             variant="outlined"
             register={register}
             name="destinationSchema"
-            disabled={readonly || globalContext?.CurrentOrg.state.is_demo ? true : false}
+            disabled={readonly || globalContext?.CurrentOrg.state.is_demo}
           ></Input>
 
           <Box sx={{ m: 2 }} />

--- a/src/components/UI/Menu/Menu.tsx
+++ b/src/components/UI/Menu/Menu.tsx
@@ -28,7 +28,7 @@ interface MenuProps {
   hasDeletePermission?: boolean;
   hasResendPermission?: boolean;
   hasResetPermission?: boolean;
-  isSyncRunning?: boolean;
+  viewMode?: boolean;
 }
 
 export const ActionsMenu: React.FC<MenuProps> = ({
@@ -46,7 +46,7 @@ export const ActionsMenu: React.FC<MenuProps> = ({
   hasDeletePermission = true,
   hasResendPermission = true,
   hasResetPermission = true,
-  isSyncRunning = false,
+  viewMode = false,
 }) => (
   <Menu
     id="basic-menu"
@@ -68,7 +68,7 @@ export const ActionsMenu: React.FC<MenuProps> = ({
       'aria-labelledby': 'basic-button',
     }}
   >
-    {isSyncRunning && handleView && (
+    {viewMode && handleView && (
       <>
         <MenuItem sx={{ my: 0 }} onClick={() => handleView()}>
           <ListItemIcon style={{ minWidth: 28 }}>
@@ -80,7 +80,7 @@ export const ActionsMenu: React.FC<MenuProps> = ({
       </>
     )}
 
-    {!isSyncRunning && handleEdit && (
+    {!viewMode && handleEdit && (
       <MenuItem sx={{ my: 0 }} onClick={() => handleEdit()} disabled={!hasEditPermission}>
         <ListItemIcon style={{ minWidth: 28 }}>
           <Image src={EditIcon} alt="edit icon" />
@@ -89,7 +89,7 @@ export const ActionsMenu: React.FC<MenuProps> = ({
       </MenuItem>
     )}
     <Divider style={{ margin: 0 }} />
-    {!isSyncRunning && handleRefresh && (
+    {!viewMode && handleRefresh && (
       <MenuItem sx={{ my: 0 }} onClick={() => handleRefresh()} disabled={!hasEditPermission}>
         <ListItemIcon style={{ minWidth: 28 }}>
           <RefreshIcon sx={{ width: 14 }} />
@@ -101,7 +101,7 @@ export const ActionsMenu: React.FC<MenuProps> = ({
       <MenuItem
         sx={{ my: 0 }}
         onClick={() => handleResendInvitation()}
-        disabled={!hasResendPermission || !isSyncRunning}
+        disabled={!hasResendPermission || !viewMode}
       >
         <ListItemIcon style={{ minWidth: 28 }}>
           <Image src={EditIcon} alt="edit icon" />
@@ -110,7 +110,7 @@ export const ActionsMenu: React.FC<MenuProps> = ({
       </MenuItem>
     )}
 
-    {!isSyncRunning && handleDelete && (
+    {!viewMode && handleDelete && (
       <Box key="fake-key">
         <Divider style={{ margin: 0 }} />
         <MenuItem
@@ -126,7 +126,7 @@ export const ActionsMenu: React.FC<MenuProps> = ({
       </Box>
     )}
     <Divider style={{ margin: 0 }} />
-    {!isSyncRunning && eleType === 'connection' && handleClearConnection && (
+    {!viewMode && eleType === 'connection' && handleClearConnection && (
       <MenuItem onClick={() => handleClearConnection()} disabled={!hasResetPermission}>
         <ListItemIcon style={{ minWidth: 28 }}>
           <RestartAltIcon sx={{ width: 16 }} />

--- a/src/components/UI/Menu/Menu.tsx
+++ b/src/components/UI/Menu/Menu.tsx
@@ -4,6 +4,7 @@ import EditIcon from '@/assets/icons/edit.svg';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import DeleteIcon from '@/assets/icons/delete.svg';
+import VisibilityIcon from '@mui/icons-material/Visibility';
 
 interface MenuProps {
   anchorEl: null | HTMLElement;
@@ -22,10 +23,12 @@ interface MenuProps {
   handleDelete?: () => void;
   handleClearConnection?: () => void;
   handleResendInvitation?: () => void;
+  handleView?: () => void;
   hasEditPermission?: boolean;
   hasDeletePermission?: boolean;
   hasResendPermission?: boolean;
   hasResetPermission?: boolean;
+  isSyncRunning?: boolean;
 }
 
 export const ActionsMenu: React.FC<MenuProps> = ({
@@ -38,10 +41,12 @@ export const ActionsMenu: React.FC<MenuProps> = ({
   handleDelete,
   handleClearConnection,
   handleResendInvitation,
+  handleView,
   hasEditPermission = true,
   hasDeletePermission = true,
   hasResendPermission = true,
   hasResetPermission = true,
+  isSyncRunning = false,
 }) => (
   <Menu
     id="basic-menu"
@@ -63,7 +68,19 @@ export const ActionsMenu: React.FC<MenuProps> = ({
       'aria-labelledby': 'basic-button',
     }}
   >
-    {handleEdit && (
+    {isSyncRunning && handleView && (
+      <>
+        <MenuItem sx={{ my: 0 }} onClick={() => handleView()}>
+          <ListItemIcon style={{ minWidth: 28 }}>
+            <VisibilityIcon sx={{ width: 16 }} />
+          </ListItemIcon>
+          View
+        </MenuItem>
+        <Divider style={{ margin: 0 }} />
+      </>
+    )}
+
+    {!isSyncRunning && handleEdit && (
       <MenuItem sx={{ my: 0 }} onClick={() => handleEdit()} disabled={!hasEditPermission}>
         <ListItemIcon style={{ minWidth: 28 }}>
           <Image src={EditIcon} alt="edit icon" />
@@ -72,7 +89,7 @@ export const ActionsMenu: React.FC<MenuProps> = ({
       </MenuItem>
     )}
     <Divider style={{ margin: 0 }} />
-    {handleRefresh && (
+    {!isSyncRunning && handleRefresh && (
       <MenuItem sx={{ my: 0 }} onClick={() => handleRefresh()} disabled={!hasEditPermission}>
         <ListItemIcon style={{ minWidth: 28 }}>
           <RefreshIcon sx={{ width: 14 }} />
@@ -84,7 +101,7 @@ export const ActionsMenu: React.FC<MenuProps> = ({
       <MenuItem
         sx={{ my: 0 }}
         onClick={() => handleResendInvitation()}
-        disabled={!hasResendPermission}
+        disabled={!hasResendPermission || !isSyncRunning}
       >
         <ListItemIcon style={{ minWidth: 28 }}>
           <Image src={EditIcon} alt="edit icon" />
@@ -93,7 +110,7 @@ export const ActionsMenu: React.FC<MenuProps> = ({
       </MenuItem>
     )}
 
-    {handleDelete && (
+    {!isSyncRunning && handleDelete && (
       <Box key="fake-key">
         <Divider style={{ margin: 0 }} />
         <MenuItem
@@ -109,7 +126,7 @@ export const ActionsMenu: React.FC<MenuProps> = ({
       </Box>
     )}
     <Divider style={{ margin: 0 }} />
-    {eleType === 'connection' && handleClearConnection && (
+    {!isSyncRunning && eleType === 'connection' && handleClearConnection && (
       <MenuItem onClick={() => handleClearConnection()} disabled={!hasResetPermission}>
         <ListItemIcon style={{ minWidth: 28 }}>
           <RestartAltIcon sx={{ width: 16 }} />


### PR DESCRIPTION
## Summary

Fixes: #1614 


https://github.com/user-attachments/assets/ba19bf10-7855-4476-8ed1-9a4ec4149e47



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to view connection details in read-only mode while a connection is syncing or locked.
  * The connection form now supports a read-only state, disabling editing of fields and hiding action buttons during sync or lock.

* **Improvements**
  * The actions menu dynamically updates its options based on the connection's sync state, showing a "View" option and restricting other actions during sync or lock.
  * The menu button remains enabled during syncing when locked, improving accessibility to connection actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->