### PR TITLE
Toggle the vertical scaling of the bars in the pipeline history

### DIFF
--- a/src/pages/pipeline/index.tsx
+++ b/src/pages/pipeline/index.tsx
@@ -311,7 +311,7 @@ export default function Home() {
           {flowRuns &&
             flowRuns.map((run: any) => {
               return (
-                <React.Fragment key={run.name}>
+                <React.Fragment key={run.deploymentName}>
                   <Typography
                     variant="body1"
                     sx={{ mt: 4, fontWeight: 700, pb: 1, color: '#092540BF' }}
@@ -382,7 +382,7 @@ export default function Home() {
                         <BarChart
                           runs={run.runs}
                           selectFlowRun={selectFlowRun}
-                          scaleToRuntime={getScaleToRuntime(run.name)}
+                          scaleToRuntime={getScaleToRuntime(run.deploymentName)}
                         />
                         <Box display="flex" justifyContent="space-between" alignItems="center">
                           <Typography variant="subtitle2" fontWeight={600}>
@@ -391,9 +391,9 @@ export default function Home() {
                           <FormControlLabel
                             control={
                               <Checkbox
-                                checked={getScaleToRuntime(run.name)}
+                                checked={getScaleToRuntime(run.deploymentName)}
                                 onChange={(e) =>
-                                  setScaleToRuntimeForFlow(run.name, e.target.checked)
+                                  setScaleToRuntimeForFlow(run.deploymentName, e.target.checked)
                                 }
                                 size="small"
                               />


### PR DESCRIPTION
Each flow-run gets a state specifying whether or not to scale the heights of its bars to the durations of their run



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a checkbox for each flow to toggle whether bar chart heights are scaled to runtime durations or displayed at full height.
  * Bar charts now reflect user preference for scaling on a per-flow basis, providing more control over data visualization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->