### PR TITLE
renamed "duration" to "billing frequency"

### DIFF
--- a/src/components/Org/CreateOrgForm.tsx
+++ b/src/components/Org/CreateOrgForm.tsx
@@ -277,7 +277,7 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
         <Controller
           name="duration"
           control={control}
-          rules={{ required: 'Duration is required' }}
+          rules={{ required: 'Billing Frequency is required' }}
           render={({ field }) => (
             <Autocomplete
               options={durationOptions}
@@ -290,7 +290,7 @@ export const CreateOrgForm = ({ closeSideMenu, showForm, setShowForm }: CreateOr
                   error={!!errors.duration}
                   helperText={errors.duration?.message}
                   sx={{ mb: 2, width: '100%' }}
-                  label="Select Duration"
+                  label="Select Billing Frequency"
                   variant="outlined"
                 />
               )}


### PR DESCRIPTION
only for the UI, did not rename variables etc

feel free to improve as required... e.g. there is no billing frequency for trials or internal accounts, so maybe this field doesn't need to be required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the label and validation message for the duration field to "Billing Frequency" in the organization creation form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->